### PR TITLE
401 Unauthorized 발생 시 로그인 다시 시키기

### DIFF
--- a/lib/http.ts
+++ b/lib/http.ts
@@ -39,9 +39,15 @@ export const http = returnFetch({
       return [url, newConfig]
     },
     response: async (response) => {
+      if (response.status === 401) {
+        storage.remove("token")
+        history.pushState(null, '', "/account/login?redirect=" + window.location.pathname)
+        throw new NetworkError(response)
+      }
       if (response.status >= 400) {
         throw new NetworkError(response)
       }
+
       return response
     },
   },


### PR DESCRIPTION
- 토큰이 만료된 경우 등에 다시 로그인을 시킵니다.
- return-fetch 쪽에서는 뭔가 useRouter 등이 안 먹는 것 같아서 history API를 직접 사용했는데, 요게 맞는지 잘 모르겠네요 😢 