### PR TITLE
퀘스트 관리 페이지에서 전체 퀘스트 조회 대신 커서링 방식 사용

### DIFF
--- a/app/(private)/quest/page.style.ts
+++ b/app/(private)/quest/page.style.ts
@@ -47,6 +47,20 @@ export const DeleteButton = styled(Button, {
   },
 })
 
+export const LoadNextPageButton = styled("button", {
+  base: {
+    padding: 8,
+    backgroundColor: "var(--leaf-primary-60)",
+    color: "white",
+    borderRadius: 4,
+    cursor: "pointer",
+    _disabled: {
+      backgroundColor: "var(--leaf-grey-80)",
+      cursor: "not-allowed",
+    },
+  },
+})
+
 export const Quests = styled("ul", {
   base: {
     display: "flex",
@@ -55,6 +69,7 @@ export const Quests = styled("ul", {
     },
   },
 })
+
 export const Quest = styled("li", {
   base: {
     padding: "4px 8px",

--- a/app/(private)/quest/page.tsx
+++ b/app/(private)/quest/page.tsx
@@ -17,7 +17,7 @@ export default function QuestList() {
   const router = useRouter()
   const { data, fetchNextPage, hasNextPage } = useClubQuestSummaries()
   const queryClient = useQueryClient()
-  const quests = data?.pages.flatMap((p) => p.items) ?? []
+  const quests = data?.pages.flatMap((p) => p.list) ?? []
 
   const regrouped = quests.reduce(
     (acc, q) => {
@@ -42,7 +42,7 @@ export default function QuestList() {
     for (const q of quests) {
       await deleteQuest({ questId: q.id })
     }
-    queryClient.invalidateQueries({ queryKey: ["@quests"] })
+    queryClient.invalidateQueries({ queryKey: ["@clubQuestSummaries"] })
     toast.success(`퀘스트가 삭제되었습니다.`)
   }
 

--- a/app/(private)/quest/page.tsx
+++ b/app/(private)/quest/page.tsx
@@ -5,18 +5,19 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { toast } from "react-toastify"
 
-import { deleteQuest, useQuests } from "@/lib/apis/api"
+import { deleteQuest } from "@/lib/apis/api"
+import { useClubQuestSummaries } from "@/(private)/quest/query";
+
 import { QuestSummary } from "@/lib/models/quest"
 
 import { Contents, Header } from "@/components/layout"
-
 import * as S from "./page.style"
 
 export default function QuestList() {
   const router = useRouter()
-  const { data } = useQuests()
+  const { data, fetchNextPage, hasNextPage } = useClubQuestSummaries()
   const queryClient = useQueryClient()
-  const quests = data ?? []
+  const quests = data?.pages.flatMap((p) => p.items) ?? []
 
   const regrouped = quests.reduce(
     (acc, q) => {
@@ -68,6 +69,7 @@ export default function QuestList() {
             </S.Quests>
           </S.Event>
         ))}
+        {hasNextPage && <S.LoadNextPageButton onClick={() => fetchNextPage()}>더 불러오기</S.LoadNextPageButton>}
       </Contents.Normal>
     </>
   )

--- a/app/(private)/quest/query.ts
+++ b/app/(private)/quest/query.ts
@@ -10,7 +10,7 @@ export function useClubQuestSummaries() {
     queryFn: ({ pageParam }) =>
       http(
         `/admin/clubQuestSummaries/cursored?${qs.stringify(
-          { cursor: pageParam, limit: 10 },
+          { cursor: pageParam, limit: 100 },
           { skipNull: true },
         )}`,
       ).then((res) => res.json() as Promise<GetCursoredClubQuestSummariesResult>),
@@ -20,6 +20,6 @@ export function useClubQuestSummaries() {
 }
 
 export interface GetCursoredClubQuestSummariesResult {
-  items: QuestSummary[]
+  list: QuestSummary[]
   cursor: string | null
 }

--- a/app/(private)/quest/query.ts
+++ b/app/(private)/quest/query.ts
@@ -1,0 +1,25 @@
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query"
+import qs from "query-string"
+
+import { http } from "@/lib/http"
+import { QuestSummary } from "@/lib/models/quest"
+
+export function useClubQuestSummaries() {
+  return useInfiniteQuery({
+    queryKey: ["@clubQuestSummaries"],
+    queryFn: ({ pageParam }) =>
+      http(
+        `/admin/clubQuestSummaries/cursored?${qs.stringify(
+          { cursor: pageParam, limit: 10 },
+          { skipNull: true },
+        )}`,
+      ).then((res) => res.json() as Promise<GetCursoredClubQuestSummariesResult>),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.cursor,
+  })
+}
+
+export interface GetCursoredClubQuestSummariesResult {
+  items: QuestSummary[]
+  cursor: string | null
+}


### PR DESCRIPTION
- https://github.com/Stair-Crusher-Club/scc-server/pull/312 <- 이 API를 사용하도록 수정합니다.