### PR TITLE
ClubQuest에 데이터 분석을 위한 필드 추가

### DIFF
--- a/lib/apis/api.ts
+++ b/lib/apis/api.ts
@@ -5,8 +5,9 @@ import { AccessibilitySummary } from "@/lib/models/accessibility"
 
 import { http } from "../http"
 import { Challenge } from "../models/challenge"
-import { QuestBuilding, QuestDetail, QuestSummary } from "../models/quest"
+import {QuestBuilding, QuestDetail, QuestPurposeType, QuestSummary} from "../models/quest"
 import { Region } from "../models/region"
+import {EpochMillisTimestamp} from "@/lib/models/common";
 
 export function useQuests() {
   return useQuery({
@@ -69,6 +70,9 @@ export async function previewDivisions(params: PreviewDivisionsParams) {
 
 type CreateQuestPayload = {
   questNamePrefix: string
+  purposeType: QuestPurposeType
+  startAt: EpochMillisTimestamp
+  endAt: EpochMillisTimestamp
   dryRunResults: ClusterPreview[]
 }
 export async function createQuest(payload: CreateQuestPayload) {

--- a/lib/models/common.ts
+++ b/lib/models/common.ts
@@ -2,3 +2,7 @@ export interface LatLng {
   lng: number
   lat: number
 }
+
+export interface EpochMillisTimestamp {
+  value: number
+}

--- a/lib/models/quest.ts
+++ b/lib/models/quest.ts
@@ -1,15 +1,24 @@
-import { LatLng } from "./common"
+import {EpochMillisTimestamp, LatLng} from "./common"
+
+export type QuestPurposeType = 'CRUSHER_CLUB' | 'DAILY_CLUB' | 'COLLABO_CLUB' | 'ESG_PARTNERS'
 
 export interface QuestSummary {
   id: string
   name: string
+  purposeType: QuestPurposeType
+  startAt: EpochMillisTimestamp
+  endAt: EpochMillisTimestamp
   shortenedUrl?: string
 }
 
 export interface QuestDetail {
   id: string
   name: string
+  purposeType: QuestPurposeType
+  startAt: EpochMillisTimestamp
+  endAt: EpochMillisTimestamp
   buildings: QuestBuilding[]
+  shortenedUrl?: string
 }
 
 export interface QuestBuilding {


### PR DESCRIPTION
## Proposed Changes
- 크게 두 가지 필드를 추가합니다.
  - 퀘스트 용도
  - 퀘스트 유효기간
- 일단 만들 때 넣기만 하고, 보여주는 건 나중에 작업하려고 합니다.
<img width="1728" alt="image" src="https://github.com/Stair-Crusher-Club/scc-admin/assets/24506624/2382fadc-9bbe-4ad5-955d-b8369353fe98">
