### PR TITLE
인증 처리 중앙화

### DIFF
--- a/app/(private)/layout.tsx
+++ b/app/(private)/layout.tsx
@@ -1,22 +1,11 @@
 "use client"
 
-import { usePathname, useRouter } from "next/navigation"
-import { useEffect } from "react"
-
 import { Sidebar } from "@/components/layout"
 import { useAuth } from "@/hooks/useAuth"
 import { Flex } from "@/styles/jsx"
 
 export default function PrivateLayout({ children }: { children: React.ReactNode }) {
-  const router = useRouter()
-  const pathname = usePathname()
   const { isAuthenticated } = useAuth()
-
-  useEffect(() => {
-    if (isAuthenticated === false) {
-      router.replace("/account/login?redirect=" + pathname)
-    }
-  }, [isAuthenticated])
 
   if (isAuthenticated === null) return undefined
   if (!isAuthenticated) return <div>로그인이 필요합니다.</div>

--- a/app/(private)/layout.tsx
+++ b/app/(private)/layout.tsx
@@ -13,7 +13,7 @@ export default function PrivateLayout({ children }: { children: React.ReactNode 
   const { isAuthenticated } = useAuth()
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (isAuthenticated === false) {
       router.replace("/account/login?redirect=" + pathname)
     }
   }, [isAuthenticated])

--- a/app/(private)/layout.tsx
+++ b/app/(private)/layout.tsx
@@ -1,31 +1,25 @@
 "use client"
 
 import { usePathname, useRouter } from "next/navigation"
-import { useEffect, useState } from "react"
-
-import { storage } from "@/lib/storage"
+import { useEffect } from "react"
 
 import { Sidebar } from "@/components/layout"
+import { useAuth } from "@/hooks/useAuth"
 import { Flex } from "@/styles/jsx"
 
 export default function PrivateLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter()
   const pathname = usePathname()
-  const [authenticated, setAuthenticated] = useState<boolean>()
+  const { isAuthenticated } = useAuth()
 
   useEffect(() => {
-    const token = storage.get("token")
-    // TODO: token 유효성 검사. 지금은 일단 있으면 오케이.
-    if (token) {
-      setAuthenticated(true)
-    } else {
-      setAuthenticated(false)
+    if (!isAuthenticated) {
       router.replace("/account/login?redirect=" + pathname)
     }
-  }, [])
+  }, [isAuthenticated])
 
-  if (authenticated === undefined) return null
-  if (!authenticated) return <div>로그인이 필요합니다.</div>
+  if (isAuthenticated === null) return undefined
+  if (!isAuthenticated) return <div>로그인이 필요합니다.</div>
   return (
     <Flex css={{ width: "full", height: "full" }}>
       <Sidebar />

--- a/app/(public)/account/login/page.tsx
+++ b/app/(public)/account/login/page.tsx
@@ -6,7 +6,8 @@ import { FormProvider, useForm } from "react-hook-form"
 import { toast } from "react-toastify"
 
 import { NetworkError, http } from "@/lib/http"
-import { storage } from "@/lib/storage"
+
+import { useAuth } from "@/hooks/useAuth"
 
 import * as S from "./page.style"
 
@@ -17,6 +18,7 @@ interface FormValues {
 export default function Page() {
   const router = useRouter()
   const form = useForm<FormValues>({ defaultValues: { username: "", password: "" } })
+  const { updateToken } = useAuth()
 
   async function onSubmit(values: FormValues) {
     try {
@@ -26,7 +28,7 @@ export default function Page() {
       })
       const token = res.headers.get("X-Scc-Access-Key")
       if (!token) return
-      storage.set("token", token)
+      updateToken(token)
       router.replace("/")
     } catch (e) {
       if (e instanceof NetworkError) {

--- a/app/components/layout/Sidebar.tsx
+++ b/app/components/layout/Sidebar.tsx
@@ -8,8 +8,8 @@ import { useEffect } from "react"
 import { useMediaQuery } from "react-responsive"
 
 import { AppState } from "@/lib/globalAtoms"
-import { storage } from "@/lib/storage"
 
+import { useAuth } from "@/hooks/useAuth"
 import Logo from "@/icons/Logo"
 import { Spacer } from "@/styles/jsx"
 
@@ -20,6 +20,7 @@ export default function Sidebar() {
   const router = useRouter()
   const isMobile = useMediaQuery({ maxWidth: 800 })
   const [appState, setAppState] = useAtom(AppState)
+  const { clearToken } = useAuth()
 
   // 윈도우 사이즈가 변할 때마다 열림 상태 초기화
   useEffect(() => {
@@ -32,11 +33,10 @@ export default function Sidebar() {
   }
 
   function logout() {
-    storage.remove("token")
+    clearToken()
     if (isMobile) {
       setAppState((s) => ({ ...s, isSidebarOpened: false }))
     }
-    router.replace("/account/login")
   }
 
   return (

--- a/app/hooks/useAuth.ts
+++ b/app/hooks/useAuth.ts
@@ -1,0 +1,56 @@
+import { atom, useAtomValue, useSetAtom } from "jotai"
+import { useEffect } from "react"
+
+import { storage } from "@/lib/storage"
+
+// * null은 초기화 되기 전 상태:storage에서 가져오기 전
+export const authAtom = atom<string | null>(null)
+
+export const initAuthAtom = atom(null, (_get, set) => {
+  const token = storage.get("token")
+  set(authAtom, token ?? null)
+})
+
+// TODO: token 유효성 검사. 지금은 일단 있으면 오케이.
+export const isAuthenticatedAtom = atom((get) => {
+  const token = get(authAtom)
+  return get(authAtom) === null ? null : !!token
+})
+
+export const authWritableAtom = atom(
+  (get) => get(authAtom),
+  (_get, set, newToken: string | null) => {
+    if (newToken) {
+      storage.set("token", newToken)
+    } else {
+      storage.remove("token")
+    }
+    set(authAtom, newToken)
+  },
+)
+
+export function useAuth() {
+  const setInit = useSetAtom(initAuthAtom)
+  const setAuth = useSetAtom(authWritableAtom)
+  const isAuthenticated = useAtomValue(isAuthenticatedAtom)
+
+  useEffect(() => {
+    setInit()
+  }, [setInit])
+
+  // 토큰 업데이트 함수 (로그인)
+  const updateToken = (token: string) => {
+    setAuth(token)
+  }
+
+  // 토큰 제거 함수 (로그아웃)
+  const clearToken = () => {
+    setAuth(null)
+  }
+
+  return {
+    isAuthenticated,
+    updateToken,
+    clearToken,
+  }
+}

--- a/app/hooks/useAuth.ts
+++ b/app/hooks/useAuth.ts
@@ -1,4 +1,5 @@
-import { atom, useAtomValue, useSetAtom } from "jotai"
+import { atom, useAtom } from "jotai"
+import { usePathname, useRouter } from "next/navigation"
 import { useEffect } from "react"
 
 import { storage } from "@/lib/storage"
@@ -6,47 +7,42 @@ import { storage } from "@/lib/storage"
 // * null은 초기화 되기 전 상태:storage에서 가져오기 전
 export const authAtom = atom<string | null>(null)
 
-export const initAuthAtom = atom(null, (_get, set) => {
-  const token = storage.get("token")
-  set(authAtom, token ?? null)
-})
-
-// TODO: token 유효성 검사. 지금은 일단 있으면 오케이.
-export const isAuthenticatedAtom = atom((get) => {
-  const token = get(authAtom)
-  return get(authAtom) === null ? null : !!token
-})
-
-export const authWritableAtom = atom(
-  (get) => get(authAtom),
-  (_get, set, newToken: string | null) => {
-    if (newToken) {
-      storage.set("token", newToken)
-    } else {
-      storage.remove("token")
-    }
-    set(authAtom, newToken)
-  },
-)
-
 export function useAuth() {
-  const setInit = useSetAtom(initAuthAtom)
-  const setAuth = useSetAtom(authWritableAtom)
-  const isAuthenticated = useAtomValue(isAuthenticatedAtom)
+  const [token, setToken] = useAtom(authAtom)
+  const router = useRouter()
+  const pathname = usePathname()
 
   useEffect(() => {
-    setInit()
-  }, [setInit])
+    if (typeof window === "undefined") {
+      return
+    }
+
+    // TODO: token 유효성 검사. 지금은 일단 있으면 오케이.
+    const authToken = storage.get("token")
+    if (authToken) {
+      setToken(authToken)
+    } else {
+      setToken(null)
+      if (pathname !== "/account/login") {
+        router.replace("/account/login?redirect=" + pathname)
+      }
+    }
+  }, [setToken, pathname])
 
   // 토큰 업데이트 함수 (로그인)
   const updateToken = (token: string) => {
-    setAuth(token)
+    storage.set("token", token)
+    setToken(token)
   }
 
   // 토큰 제거 함수 (로그아웃)
   const clearToken = () => {
-    setAuth(null)
+    storage.remove("token")
+    setToken(null)
+    router.replace("/account/login")
   }
+
+  const isAuthenticated = token === null ? null : !!token
 
   return {
     isAuthenticated,

--- a/app/modals/BuildingDetailSheet/BuildingDetailSheet.desktop.tsx
+++ b/app/modals/BuildingDetailSheet/BuildingDetailSheet.desktop.tsx
@@ -6,14 +6,13 @@ import { useEffect, useMemo, useState } from "react"
 import { deleteQuestTargetBuilding, useQuestBuilding } from "@/lib/apis/api"
 import { QuestBuilding, QuestPlace } from "@/lib/models/quest"
 
+import { useAuth } from "@/hooks/useAuth"
 import Reload from "@/icons/Reload"
 
+import deleteIcon from "../../../public/delete_button.png"
 import RightSheet from "../_template/RightSheet"
 import * as S from "./BuildingDetailSheet.style"
 import PlaceCard from "./PlaceCard"
-import { storage } from "@/lib/storage"
-
-import deleteIcon from "../../../public/delete_button.png"
 
 interface Props extends BasicModalProps {
   building: QuestBuilding
@@ -22,18 +21,10 @@ interface Props extends BasicModalProps {
 
 export const defaultOverlayOptions = { closeDelay: 200, dim: false }
 export default function BuildingDetailSheet({ building: initialData, questId, visible, close }: Props) {
-  const [sortedPlaces, setSortedPlaces] = useState<QuestPlace[]>([]);
+  const [sortedPlaces, setSortedPlaces] = useState<QuestPlace[]>([])
   const { data: building } = useQuestBuilding({ questId, buildingId: initialData.buildingId })
   const queryClient = useQueryClient()
-  const [authenticated, setAuthenticated] = useState<boolean>()
-  useEffect(() => {
-    const token = storage.get("token")
-    if (token) {
-      setAuthenticated(true)
-    } else {
-      setAuthenticated(false)
-    }
-  }, [])
+  const { isAuthenticated } = useAuth()
 
   function reloadQuest() {
     queryClient.invalidateQueries({ queryKey: ["@quests", questId] })
@@ -42,9 +33,9 @@ export default function BuildingDetailSheet({ building: initialData, questId, vi
   async function deleteBuilding() {
     if (building) {
       if (!confirm(`[${building.name}] 건물을 정말 삭제하시겠습니까?`)) return
-      await deleteQuestTargetBuilding(questId, building!);
-      reloadQuest();
-      close();
+      await deleteQuestTargetBuilding(questId, building!)
+      reloadQuest()
+      close()
     }
   }
 
@@ -79,15 +70,11 @@ export default function BuildingDetailSheet({ building: initialData, questId, vi
       <S.ReloadButton onClick={reloadQuest}>
         <Reload size={24} />
       </S.ReloadButton>
-      {
-        authenticated
-          ? (
-            <S.DeleteButton onClick={deleteBuilding}>
-              <Image src={deleteIcon} alt="삭제" style={{ width: 24, height: 24 }} />
-            </S.DeleteButton>
-          )
-          : null
-      }
+      {isAuthenticated && (
+        <S.DeleteButton onClick={deleteBuilding}>
+          <Image src={deleteIcon} alt="삭제" style={{ width: 24, height: 24 }} />
+        </S.DeleteButton>
+      )}
     </S.CustomTitle>
   )
 

--- a/app/modals/BuildingDetailSheet/BuildingDetailSheet.mobile.tsx
+++ b/app/modals/BuildingDetailSheet/BuildingDetailSheet.mobile.tsx
@@ -8,14 +8,13 @@ import { deleteQuestTargetBuilding, useQuestBuilding } from "@/lib/apis/api"
 import { AppState } from "@/lib/globalAtoms"
 import { QuestBuilding, QuestPlace } from "@/lib/models/quest"
 
+import { useAuth } from "@/hooks/useAuth"
 import Reload from "@/icons/Reload"
 import BottomSheet from "@/modals/_template/BottomSheet"
 
+import deleteIcon from "../../../public/delete_button.png"
 import * as S from "./BuildingDetailSheet.style"
 import PlaceCard from "./PlaceCard"
-
-import deleteIcon from "../../../public/delete_button.png"
-import { storage } from "@/lib/storage"
 
 interface Props extends BasicModalProps {
   building: QuestBuilding
@@ -24,19 +23,11 @@ interface Props extends BasicModalProps {
 
 export const defaultOverlayOptions = { closeDelay: 200, dim: false }
 export default function BuildingDetailSheet({ building: initialData, questId, visible, close }: Props) {
-  const [sortedPlaces, setSortedPlaces] = useState<QuestPlace[]>([]);
+  const [sortedPlaces, setSortedPlaces] = useState<QuestPlace[]>([])
   const { data: building } = useQuestBuilding({ questId, buildingId: initialData.buildingId })
   const [appState, setAppState] = useAtom(AppState)
   const queryClient = useQueryClient()
-  const [authenticated, setAuthenticated] = useState<boolean>()
-  useEffect(() => {
-    const token = storage.get("token")
-    if (token) {
-      setAuthenticated(true)
-    } else {
-      setAuthenticated(false)
-    }
-  }, [])
+  const { isAuthenticated } = useAuth()
 
   useEffect(() => {
     setAppState((prev) => ({ ...prev, isHeaderHidden: true }))
@@ -52,9 +43,9 @@ export default function BuildingDetailSheet({ building: initialData, questId, vi
   async function deleteBuilding() {
     if (building) {
       if (!confirm(`[${building.name}] 건물을 정말 삭제하시겠습니까?`)) return
-      await deleteQuestTargetBuilding(questId, building!);
-      reloadQuest();
-      close();
+      await deleteQuestTargetBuilding(questId, building!)
+      reloadQuest()
+      close()
     }
   }
 
@@ -89,15 +80,11 @@ export default function BuildingDetailSheet({ building: initialData, questId, vi
       <S.ReloadButton onClick={reloadQuest}>
         <Reload size={24} />
       </S.ReloadButton>
-      {
-        authenticated
-          ? (
-            <S.DeleteButton onClick={deleteBuilding}>
-              <Image src={deleteIcon} alt="삭제 " style={{ width: 32, height: 32 }} />
-            </S.DeleteButton>
-          )
-          : null
-      }
+      {isAuthenticated && (
+        <S.DeleteButton onClick={deleteBuilding}>
+          <Image src={deleteIcon} alt="삭제 " style={{ width: 32, height: 32 }} />
+        </S.DeleteButton>
+      )}
     </S.CustomTitle>
   )
 

--- a/app/modals/BuildingDetailSheet/PlaceCard.tsx
+++ b/app/modals/BuildingDetailSheet/PlaceCard.tsx
@@ -1,16 +1,16 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import Image from "next/image"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { toast } from "react-toastify"
 
 import { deleteQuestTargetPlace, updateQuestStatus } from "@/lib/apis/api"
 import { QuestPlace } from "@/lib/models/quest"
 
 import Checkbox from "@/components/Checkbox"
+import { useAuth } from "@/hooks/useAuth"
 
-import { storage } from "@/lib/storage"
-import naverMapIcon from "../../../public/naver_map.jpg"
 import deleteIcon from "../../../public/delete_button.png"
+import naverMapIcon from "../../../public/naver_map.jpg"
 import * as S from "./PlaceCard.style"
 
 interface Props {
@@ -22,16 +22,7 @@ interface Props {
 export default function PlaceCard({ place, questId, onUpdate, onDelete }: Props) {
   const [isClosed, setClosed] = useState(place.isClosed)
   const [isNotAccessible, setNotAccessible] = useState(place.isNotAccessible)
-  const [authenticated, setAuthenticated] = useState<boolean>()
-
-  useEffect(() => {
-    const token = storage.get("token")
-    if (token) {
-      setAuthenticated(true)
-    } else {
-      setAuthenticated(false)
-    }
-  }, [])
+  const { isAuthenticated } = useAuth()
 
   const queryClient = useQueryClient()
   const updateStatus = useMutation({
@@ -85,7 +76,7 @@ export default function PlaceCard({ place, questId, onUpdate, onDelete }: Props)
 
   const deletePlace = async () => {
     if (!confirm(`[${place.name}] 장소를 정말 삭제하시겠습니까?`)) return
-    await deleteQuestTargetPlace(questId, place);
+    await deleteQuestTargetPlace(questId, place)
     onDelete?.(place)
   }
 
@@ -114,13 +105,11 @@ export default function PlaceCard({ place, questId, onUpdate, onDelete }: Props)
           <S.Button onClick={openNaverMap}>
             <Image src={naverMapIcon} alt="네이버 지도" style={{ width: 24, height: 24 }} />
           </S.Button>
-          {
-            authenticated ?
-              <S.Button onClick={deletePlace}>
-                <Image src={deleteIcon} alt="삭제 " style={{ width: 24, height: 24 }} />
-              </S.Button>
-              : null
-          }
+          {isAuthenticated && (
+            <S.Button onClick={deletePlace}>
+              <Image src={deleteIcon} alt="삭제 " style={{ width: 24, height: 24 }} />
+            </S.Button>
+          )}
         </S.PlaceName>
       </S.NameColumn>
       <S.ActionsColumn>


### PR DESCRIPTION
[퀘스트 장소/건물 삭제 지원 PR](https://github.com/Stair-Crusher-Club/scc-admin/pull/29)에서 isAuthenticated 처리가 중앙화가 필요하다는 의견을 보고 작업했습니다.

- 커스텀 storage 기반으로 token을 관리하는 jotai atom 구성
- 관련 atom들과 useAuth 훅을 하나의 파일로 통합해 관리
  - isAuthenticatedAtom
    - null: 토큰을 초기화하기 전 상태 (storage에서 가져오기 전)
    - true: 유효한 토큰
    - false: 유효하지 않은 토큰 (현재는 검증하고 있지않음)
- useAuth 훅
  - 초기화 로직을 useAuth 훅 useEffect에서 실행
  - 로그인 시 updateToken(token)
  - 로그아웃 시 clearToken()