### PR TITLE
어드민 푸시 보내기에 웹뷰 여는 딥링크 옵션 추가

### DIFF
--- a/app/(private)/notification/page.tsx
+++ b/app/(private)/notification/page.tsx
@@ -40,7 +40,6 @@ const headerVariantOptions: Option[] = [
   { label: "앱 내부처럼 보이도록 (상단에 뒤로가기 버튼이 있다)", value: "navigation" },
 ]
 
-// Frequently used webview deeplinks
 const predefinedWebviews: WebviewOption[] = [
   {
     label: "정보 등록/조회 가이드",

--- a/app/(private)/notification/page.tsx
+++ b/app/(private)/notification/page.tsx
@@ -15,24 +15,55 @@ import * as S from "./page.style"
 interface Option {
   label: string
   value: string
+}
+
+interface DeepLinkOption extends Option {
   isArgumentRequired: boolean
 }
 
-const deepLinkOptions: Option[] = [
+interface WebviewOption extends Option {
+  fixedTitle: string
+  headerVariant: string
+}
+
+const deepLinkOptions: DeepLinkOption[] = [
   { label: "홈", value: "stair-crusher://", isArgumentRequired: false },
   { label: "프로필", value: "stair-crusher://profile", isArgumentRequired: false },
   { label: "설정", value: "stair-crusher://setting", isArgumentRequired: false },
   { label: "장소", value: "stair-crusher://place", isArgumentRequired: true },
   { label: "챌린지", value: "stair-crusher://challenge", isArgumentRequired: true },
+  { label: "웹뷰", value: "stair-crusher://webview", isArgumentRequired: false },
 ]
+
+const headerVariantOptions: Option[] = [
+  { label: "브라우저처럼 열리도록 (상단에 X 버튼이 있다)", value: "appbar" },
+  { label: "앱 내부처럼 보이도록 (상단에 뒤로가기 버튼이 있다)", value: "navigation" },
+]
+
+// Frequently used webview deeplinks
+const predefinedWebviews: WebviewOption[] = [
+  {
+    label: "정보 등록/조회 가이드",
+    value: "https://admin.staircrusher.club/public/guide?tab=register",
+    fixedTitle: "정보 등록/조회 가이드",
+    headerVariant: "navigation",
+  },
+]
+
+const createWebviewDeepLink = (url: string, fixedTitle: string, headerVariant: string): string => {
+  return `stair-crusher://webview?url=${encodeURIComponent(url)}&fixedTitle=${encodeURIComponent(fixedTitle)}&headerVariant=${encodeURIComponent(headerVariant)}`
+}
 
 export default function NotificationPage() {
   interface SendPushNotificationFormValues {
     userIds: string
     title?: string
     body: string
-    deepLink?: Option
+    deepLink?: DeepLinkOption
     deepLinkArgument?: string
+    webviewUrl?: string
+    webviewFixedTitle?: string
+    webviewHeaderVariant?: Option
   }
 
   const form = useForm<SendPushNotificationFormValues>({
@@ -42,8 +73,27 @@ export default function NotificationPage() {
       body: "",
       deepLink: deepLinkOptions[0],
       deepLinkArgument: "",
+      webviewUrl: "",
+      webviewFixedTitle: "",
+      webviewHeaderVariant: undefined,
     },
   })
+
+  const handlePredefinedWebviewChange = (option: any) => {
+    const typedOption = option as WebviewOption
+    if (!typedOption || !typedOption.value) {
+      form.setValue("webviewUrl", "")
+      form.setValue("webviewFixedTitle", "")
+      form.setValue("webviewHeaderVariant", undefined)
+      return
+    }
+    form.setValue("webviewUrl", typedOption.value)
+    form.setValue("webviewFixedTitle", typedOption.fixedTitle)
+    form.setValue(
+      "webviewHeaderVariant",
+      headerVariantOptions.find((option) => option.value === typedOption.headerVariant),
+    )
+  }
 
   async function handleSendPushNotification(formValues: SendPushNotificationFormValues) {
     try {
@@ -56,7 +106,18 @@ export default function NotificationPage() {
 
       let deepLinkToUse
       if (formValues.deepLink && formValues.deepLink.value.length > 0) {
-        if (formValues.deepLink.isArgumentRequired) {
+        if (formValues.deepLink.value === "stair-crusher://webview") {
+          // Validate webview fields
+          if (!formValues.webviewUrl || !formValues.webviewFixedTitle || !formValues.webviewHeaderVariant) {
+            toast.error("웹뷰 URL, 고정 제목, 헤더 타입을 모두 입력하세요.")
+            return
+          }
+          deepLinkToUse = createWebviewDeepLink(
+            formValues.webviewUrl,
+            formValues.webviewFixedTitle,
+            formValues.webviewHeaderVariant.value,
+          )
+        } else if (formValues.deepLink.isArgumentRequired) {
           if (!formValues.deepLinkArgument || formValues.deepLinkArgument.length === 0) {
             toast.error("딥링크 상세 정보를 입력하세요.")
             return
@@ -122,13 +183,41 @@ export default function NotificationPage() {
             <S.InputTitle>딥링크</S.InputTitle>
             <Combobox name="deepLink" options={deepLinkOptions} placeholder="딥링크" />
 
-            <S.InputTitle>딥링크 상세 (Ex. 장소 ID, 챌린지 ID)</S.InputTitle>
-            <TextInput
-              type="text"
-              name="deepLinkArgument"
-              placeholder="딥링크 상세 정보 (Ex. 장소 ID)"
-              disabled={!deepLinkWatch || !deepLinkWatch.isArgumentRequired}
-            />
+            {deepLinkWatch && deepLinkWatch.value === "stair-crusher://webview" ? (
+              <>
+                <S.InputTitle>자주 쓰는 웹뷰 딥링크</S.InputTitle>
+                <Combobox
+                  name="predefinedWebview"
+                  options={predefinedWebviews}
+                  placeholder="자주 쓰는 웹뷰 딥링크 선택"
+                  onChange={(option) => {
+                    handlePredefinedWebviewChange(option)
+                  }}
+                  isClearable={true}
+                />
+                <S.InputTitle>웹뷰 URL (url 에 해당하는 부분만 넣어주세요)</S.InputTitle>
+                <TextInput type="text" name="webviewUrl" placeholder="웹뷰로 열 URL" required={true} />
+                <S.InputTitle>제목</S.InputTitle>
+                <TextInput type="text" name="webviewFixedTitle" placeholder="웹뷰 상단 제목" required={true} />
+                <S.InputTitle>헤더 타입</S.InputTitle>
+                <Combobox
+                  name="webviewHeaderVariant"
+                  options={headerVariantOptions}
+                  placeholder="헤더 타입 선택"
+                  required={true}
+                />
+              </>
+            ) : (
+              <>
+                <S.InputTitle>딥링크 상세 (Ex. 장소 ID, 챌린지 ID)</S.InputTitle>
+                <TextInput
+                  type="text"
+                  name="deepLinkArgument"
+                  placeholder="딥링크 상세 정보 (Ex. 장소 ID)"
+                  disabled={!deepLinkWatch || !deepLinkWatch.isArgumentRequired}
+                />
+              </>
+            )}
 
             <S.Button type="submit">푸시 알림 보내기</S.Button>
           </form>


### PR DESCRIPTION
- 웹뷰용 딥링크 옵션을 추가했습니다
- 매번 입력하기 귀찮을 수 있으므로 / 예시를 보여주기 위해 자주 쓰는 딥링크 옵션도 추가했습니다 (선택시 prefill 해줌)
![image](https://github.com/user-attachments/assets/9c2fe24f-640f-42e8-8a93-f89783ccfa86)
![image](https://github.com/user-attachments/assets/0c4c61e5-fd38-4102-9157-2477e329bf9e)
