### PR TITLE
feat: create image secret before deployment

### DIFF
--- a/helm-chart/scc-admin-frontend/templates/deploy-secret-serviceaccount.yaml
+++ b/helm-chart/scc-admin-frontend/templates/deploy-secret-serviceaccount.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "scc-admin-frontend.serviceAccountName" . }}-deploy-secret
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "10"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: create-secrets
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "10"
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["secrets"]
+    verbs: ["create", "patch", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: create-secrets-to-{{ include "scc-admin-frontend.serviceAccountName" . }}-deploy-secret
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "10"
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "scc-admin-frontend.serviceAccountName" . }}-deploy-secret
+roleRef:
+  kind: Role
+  name: create-secrets
+  apiGroup: rbac.authorization.k8s.io

--- a/helm-chart/scc-admin-frontend/templates/deployment.yaml
+++ b/helm-chart/scc-admin-frontend/templates/deployment.yaml
@@ -20,10 +20,8 @@ spec:
       labels:
         {{- include "scc-admin-frontend.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        - name: {{ include "scc-admin-frontend.fullname" . }}-ecr-registry
       serviceAccountName: {{ include "scc-admin-frontend.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -33,15 +31,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: AWS_STS_REGIONAL_ENDPOINTS
-              value: regional
-            - name: AWS_REGION
-              value: ap-northeast-2
-            - name: AWS_ROLE_ARN
-              value: "{{ .Values.aws.roleArn }}"
-            - name: AWS_WEB_IDENTITY_TOKEN_FILE
-              value: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -62,19 +51,6 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          volumeMounts:
-            - name: aws-iam-token
-              mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
-              readOnly: true
-      volumes:
-        - name: aws-iam-token
-          projected:
-            defaultMode: 420
-            sources:
-              - serviceAccountToken:
-                  audience: sts.amazonaws.com
-                  expirationSeconds: 86400
-                  path: token
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/scc-admin-frontend/templates/ecr-login-job.yaml
+++ b/helm-chart/scc-admin-frontend/templates/ecr-login-job.yaml
@@ -1,0 +1,60 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "scc-admin-frontend.fullname" . }}-ecr-login-job
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "20"
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ include "scc-admin-frontend.serviceAccountName" . }}-deploy-secret
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: amazon/aws-cli:2.15.28
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              # Define variables for clarity
+              SECRET_NAME="{{ include "scc-admin-frontend.fullname" . }}-ecr-registry"
+              NAMESPACE="{{ .Release.Namespace }}"
+              DOCKER_SERVER="291889421067.dkr.ecr.ap-northeast-2.amazonaws.com"
+              
+              # Get temporary ECR password from AWS
+              DOCKER_PASSWORD=$(aws ecr get-login-password --region ap-northeast-2)
+              
+              # Create or update the imagePullSecret.
+              kubectl create secret docker-registry "${SECRET_NAME}" \
+                --namespace "${NAMESPACE}" \
+                --docker-server="${DOCKER_SERVER}" \
+                --docker-username="AWS" \
+                --docker-password="${DOCKER_PASSWORD}" \
+                --dry-run=client -o yaml | kubectl apply -f -
+          env:
+            - name: AWS_STS_REGIONAL_ENDPOINTS
+              value: regional
+            - name: AWS_REGION
+              value: ap-northeast-2
+            - name: AWS_ROLE_ARN
+              value: "{{ .Values.deploySecret.awsRoleArn }}"
+            - name: AWS_WEB_IDENTITY_TOKEN_FILE
+              value: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+          volumeMounts:
+            - name: aws-iam-token
+              mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+              readOnly: true
+      volumes:
+        - name: aws-iam-token
+          projected:
+            defaultMode: 420
+            sources:
+              - serviceAccountToken:
+                  audience: sts.amazonaws.com
+                  expirationSeconds: 86400
+                  path: token
+      restartPolicy: Never
+  backoffLimit: 3

--- a/helm-chart/scc-admin-frontend/values-dev.yaml
+++ b/helm-chart/scc-admin-frontend/values-dev.yaml
@@ -80,6 +80,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-aws:
-  roleArn: arn:aws:iam::291889421067:role/scc-admin-frontend-dev

--- a/helm-chart/scc-admin-frontend/values-dev.yaml
+++ b/helm-chart/scc-admin-frontend/values-dev.yaml
@@ -13,7 +13,6 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest-rc"
 
-imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 

--- a/helm-chart/scc-admin-frontend/values-prod.yaml
+++ b/helm-chart/scc-admin-frontend/values-prod.yaml
@@ -11,7 +11,6 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "0.4.4"
-imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 serviceAccount:

--- a/helm-chart/scc-admin-frontend/values-prod.yaml
+++ b/helm-chart/scc-admin-frontend/values-prod.yaml
@@ -66,6 +66,3 @@ autoscaling:
 nodeSelector: {}
 tolerations: []
 affinity: {}
-
-aws:
-  roleArn: arn:aws:iam::291889421067:role/scc-admin-frontend


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-install and pre-upgrade Kubernetes Job to automate ECR Docker registry secret creation.
  * Introduced a dedicated ServiceAccount, Role, and RoleBinding for managing secret creation during deployment.

* **Chores**
  * Removed AWS-related configuration and environment variables from deployment manifests and values files.
  * Simplified image pull secret handling in deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->