### PR TITLE
fix: 출석부 테이블 조 컬럼 정렬 버그 수정

### DIFF
--- a/lib/notion-view.ts
+++ b/lib/notion-view.ts
@@ -180,5 +180,11 @@ function getTextValue(row: any, propName: string): string {
   if (prop.type === "rich_text") {
     return (prop.rich_text ?? []).map((t: any) => t.plain_text).join("")
   }
+  if (prop.type === "select") {
+    return prop.select?.name ?? ""
+  }
+  if (prop.type === "number") {
+    return String(prop.number ?? "")
+  }
   return ""
 }


### PR DESCRIPTION
## Summary
- 출석부 테이블에서 `조` 컬럼이 `select` 타입일 때 정렬이 동작하지 않는 버그 수정
- `getTextValue`가 `title`/`rich_text`만 처리하고 `select`/`number` 타입을 무시하여 모든 row의 조 값이 빈 문자열로 반환됨
- `select`, `number` 타입 처리를 추가하여 조 ASC → 유형 → 이름 ASC 정렬이 정상 동작

## Test plan
- [x] `pnpm build` 통과
- [ ] https://admin.staircrusher.club/attendance/328c9499-b060-80a1-a82a-f1a578c6be03 에서 조별 정렬 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved support for working with additional Notion property types, including select and number fields, for better data handling and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->