### PR TITLE
feat: 어드민 개선 - 청크 검색, 퀘스트 이름 변경, 그룹 헤더

### DIFF
--- a/app/(private)/chunks/crawl/page.tsx
+++ b/app/(private)/chunks/crawl/page.tsx
@@ -3,6 +3,7 @@
 import clip from "polygon-clipping"
 import { useEffect, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
+import { toast } from "react-toastify"
 
 import { LocationDTO } from "@/lib/generated-sources/openapi"
 
@@ -27,8 +28,10 @@ interface FormValues {
 }
 export default function CrawlPage() {
   const mode = useRef<InputMode>("POLYGON")
+  const mapRef = useRef<kakao.maps.Map>()
   const [status, setCrawlingStatus] = useState<CrawlingStatus>("WAITING")
   const [chunks, setChunks] = useState<Chunk[]>([])
+  const [searchKeyword, setSearchKeyword] = useState("")
   const timeout = useRef<number | null>(null)
   const form = useForm<FormValues>({ defaultValues: { points: [], circle: {} } })
   const crawling = useCrawling()
@@ -48,7 +51,23 @@ export default function CrawlPage() {
     }
   }
 
+  function handleSearch() {
+    if (!searchKeyword.trim() || !mapRef.current) return
+    const ps = new kakao.maps.services.Places()
+    ps.keywordSearch(searchKeyword, (result, searchStatus) => {
+      if (searchStatus === kakao.maps.services.Status.OK && result.length > 0) {
+        const place = result[0]
+        const latlng = new kakao.maps.LatLng(parseFloat(place.y), parseFloat(place.x))
+        mapRef.current!.panTo(latlng)
+        toast.info(`${place.place_name}(으)로 지도를 움직입니다`)
+      } else {
+        toast.warn("검색 결과가 없습니다")
+      }
+    })
+  }
+
   function initializeMap(map: kakao.maps.Map) {
+    mapRef.current = map
     kakao.maps.event.addListener(map, "mousedown", (e: kakao.maps.event.MouseEvent) => handleMouseDown(e))
     kakao.maps.event.addListener(map, "mouseup", (e: kakao.maps.event.MouseEvent) => handleMouseUp(e))
     kakao.maps.event.addListener(map, "click", (e: kakao.maps.event.MouseEvent) => handleClick(e))
@@ -212,6 +231,15 @@ export default function CrawlPage() {
               />
             ))}
         </Map>
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10">
+          <input
+            className="px-3 py-2 rounded-md shadow-md border bg-white text-sm w-64"
+            placeholder="장소 검색 (예: 강남역, 종로구)"
+            value={searchKeyword}
+            onChange={(e) => setSearchKeyword(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && !e.nativeEvent.isComposing && handleSearch()}
+          />
+        </div>
       </div>
     </Contents>
   )

--- a/app/(private)/quest/group/[groupId]/page.style.ts
+++ b/app/(private)/quest/group/[groupId]/page.style.ts
@@ -1,9 +1,29 @@
 import { styled } from "@/styles/jsx"
 
+export const GroupHeader = styled("div", {
+  base: {
+    display: "flex",
+    alignItems: "center",
+    gap: "12px",
+    padding: "12px 16px",
+    borderBottom: "1px solid #e0e0e0",
+    backgroundColor: "#fff",
+  },
+})
+
+export const GroupName = styled("h2", {
+  base: {
+    fontSize: "18px",
+    fontWeight: 700,
+    color: "#333",
+    margin: 0,
+  },
+})
+
 export const Container = styled("div", {
   base: {
     display: "flex",
-    height: "calc(100vh - 60px)",
+    height: "calc(100vh - 105px)",
     width: "100%",
     position: "relative",
   },

--- a/app/(private)/quest/group/[groupId]/page.tsx
+++ b/app/(private)/quest/group/[groupId]/page.tsx
@@ -239,9 +239,16 @@ export default function QuestGroupPage({ params }: PageProps) {
     )
   }
 
+  const questGroupName = quests.length > 0 ? getQuestGroupName(quests[0].name) : undefined
+
   return (
     <>
       <Contents>
+        {questGroupName && (
+          <S.GroupHeader>
+            <S.GroupName>{questGroupName}</S.GroupName>
+          </S.GroupHeader>
+        )}
         <S.Container>
           {/* 좌측 퀘스트 목록 */}
           <S.LeftPanel>

--- a/app/(private)/quest/page.style.ts
+++ b/app/(private)/quest/page.style.ts
@@ -46,6 +46,13 @@ export const ManageGroupButton = styled(Button, {
   },
 })
 
+export const RenameButton = styled(Button, {
+  base: {
+    borderColor: "#FF9800",
+    color: "#FF9800",
+  },
+})
+
 export const ShareButton = styled(Button, {
   base: {
     borderColor: "#1D85FF",

--- a/app/(private)/quest/page.tsx
+++ b/app/(private)/quest/page.tsx
@@ -3,15 +3,23 @@
 import { useQueryClient } from "@tanstack/react-query"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
+import { useState } from "react"
 import { toast } from "react-toastify"
 
-import { deleteQuest } from "@/lib/apis/api"
+import { deleteQuest, renameQuestGroup } from "@/lib/apis/api"
 import { ClubQuestSummaryDTO } from "@/lib/generated-sources/openapi"
 
 import { useClubQuestSummaries } from "@/(private)/quest/query"
 import { Contents } from "@/components/layout"
 import { PageActions } from "@/components/page-actions"
 import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 
 import * as S from "./page.style"
 import { getQuestGroupName } from "./util"
@@ -21,6 +29,10 @@ export default function QuestList() {
   const { data, fetchNextPage, hasNextPage } = useClubQuestSummaries()
   const queryClient = useQueryClient()
   const quests = data?.pages.flatMap((p) => p.list) ?? []
+
+  const [renameTarget, setRenameTarget] = useState<{ groupId: string; currentName: string } | null>(null)
+  const [newName, setNewName] = useState("")
+  const [isRenaming, setIsRenaming] = useState(false)
 
   const regrouped = quests.reduce(
     (acc, q) => {
@@ -54,6 +66,26 @@ export default function QuestList() {
     toast.success(`퀘스트가 삭제되었습니다.`)
   }
 
+  function openRenameDialog(groupId: string, currentName: string) {
+    setRenameTarget({ groupId, currentName })
+    setNewName(currentName)
+  }
+
+  async function handleRename() {
+    if (!renameTarget || !newName.trim()) return
+    setIsRenaming(true)
+    try {
+      await renameQuestGroup({ groupId: renameTarget.groupId, questNamePrefix: newName.trim() })
+      queryClient.invalidateQueries({ queryKey: ["@clubQuestSummaries"] })
+      toast.success("퀘스트 이름이 변경되었습니다.")
+      setRenameTarget(null)
+    } catch {
+      toast.error("퀘스트 이름 변경에 실패했습니다.")
+    } finally {
+      setIsRenaming(false)
+    }
+  }
+
   return (
     <Contents.Normal>
       <PageActions>
@@ -66,9 +98,14 @@ export default function QuestList() {
               <S.CreatedAt></S.CreatedAt>
               {quests[0].groupId
                 ? (
-                  <S.ManageGroupButton onClick={() => router.push(`/quest/group/${encodeURIComponent(quests[0].groupId!)}`)}>
-                    그룹 관리
-                  </S.ManageGroupButton>
+                  <>
+                    <S.ManageGroupButton onClick={() => router.push(`/quest/group/${encodeURIComponent(quests[0].groupId!)}`)}>
+                      그룹 관리
+                    </S.ManageGroupButton>
+                    <S.RenameButton onClick={() => openRenameDialog(quests[0].groupId!, questGroupName)}>
+                      이름 변경
+                    </S.RenameButton>
+                  </>
                 )
                 : null
               }
@@ -87,6 +124,28 @@ export default function QuestList() {
           </S.QuestRow>
         ))}
       {hasNextPage && <S.LoadNextPageButton onClick={() => fetchNextPage()}>더 불러오기</S.LoadNextPageButton>}
+
+      <Dialog open={!!renameTarget} onOpenChange={(open) => !open && setRenameTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>퀘스트 이름 변경</DialogTitle>
+          </DialogHeader>
+          <input
+            className="w-full px-3 py-2 border rounded-md text-sm"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && !e.nativeEvent.isComposing && handleRename()}
+            placeholder="새 퀘스트 이름"
+            autoFocus
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRenameTarget(null)}>취소</Button>
+            <Button onClick={handleRename} disabled={isRenaming || !newName.trim()}>
+              {isRenaming ? "변경 중..." : "변경"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </Contents.Normal>
   )
 }

--- a/lib/apis/api.ts
+++ b/lib/apis/api.ts
@@ -224,6 +224,16 @@ export async function moveQuestTargetPlace({
   })
 }
 
+export async function renameQuestGroup({
+  groupId,
+  questNamePrefix,
+}: {
+  groupId: string
+  questNamePrefix: string
+}) {
+  return api.default.renameClubQuestGroup(groupId, { questNamePrefix })
+}
+
 export function useChallenges() {
   return useQuery({
     queryKey: ["@challenges"],

--- a/lib/generated-sources/openapi/api.ts
+++ b/lib/generated-sources/openapi/api.ts
@@ -4806,6 +4806,19 @@ export type QuestTargetPlaceCategoryEnumDTO = typeof QuestTargetPlaceCategoryEnu
 
 
 /**
+ * 퀘스트 그룹 이름 변경 요청
+ * @export
+ * @interface RenameClubQuestGroupRequestDto
+ */
+export interface RenameClubQuestGroupRequestDto {
+    /**
+     * 새 퀘스트 이름 prefix
+     * @type {string}
+     * @memberof RenameClubQuestGroupRequestDto
+     */
+    'questNamePrefix': string;
+}
+/**
  * 
  * @export
  * @enum {string}
@@ -9244,6 +9257,50 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
+         * @summary 퀘스트 그룹의 이름(퀘스트 이름 prefix)을 변경한다.
+         * @param {string} groupId 퀘스트 그룹 식별자
+         * @param {RenameClubQuestGroupRequestDto} renameClubQuestGroupRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        renameClubQuestGroup: async (groupId: string, renameClubQuestGroupRequestDto: RenameClubQuestGroupRequestDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'groupId' is not null or undefined
+            assertParamExists('renameClubQuestGroup', 'groupId', groupId)
+            // verify required parameter 'renameClubQuestGroupRequestDto' is not null or undefined
+            assertParamExists('renameClubQuestGroup', 'renameClubQuestGroupRequestDto', renameClubQuestGroupRequestDto)
+            const localVarPath = `/clubQuests/byGroup/{groupId}/name`
+                .replace(`{${"groupId"}}`, encodeURIComponent(String(groupId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Admin required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(renameClubQuestGroupRequestDto, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary 지정된 지역 내의 장소를 지도 API를 통해 크롤링해서 계단정복지도 서버 DB에 캐싱한다.
          * @param {StartPlaceCrawlingRequestDTO} startPlaceCrawlingRequestDTO 
          * @param {*} [options] Override http request option.
@@ -9632,6 +9689,18 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @summary 퀘스트 그룹의 이름(퀘스트 이름 prefix)을 변경한다.
+         * @param {string} groupId 퀘스트 그룹 식별자
+         * @param {RenameClubQuestGroupRequestDto} renameClubQuestGroupRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async renameClubQuestGroup(groupId: string, renameClubQuestGroupRequestDto: RenameClubQuestGroupRequestDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.renameClubQuestGroup(groupId, renameClubQuestGroupRequestDto, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
          * @summary 지정된 지역 내의 장소를 지도 API를 통해 크롤링해서 계단정복지도 서버 DB에 캐싱한다.
          * @param {StartPlaceCrawlingRequestDTO} startPlaceCrawlingRequestDTO 
          * @param {*} [options] Override http request option.
@@ -9958,6 +10027,17 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         notificationsPushSchedulesScheduleIdPut(scheduleId: string, adminUpdatePushNotificationScheduleRequestDTO: AdminUpdatePushNotificationScheduleRequestDTO, options?: any): AxiosPromise<void> {
             return localVarFp.notificationsPushSchedulesScheduleIdPut(scheduleId, adminUpdatePushNotificationScheduleRequestDTO, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary 퀘스트 그룹의 이름(퀘스트 이름 prefix)을 변경한다.
+         * @param {string} groupId 퀘스트 그룹 식별자
+         * @param {RenameClubQuestGroupRequestDto} renameClubQuestGroupRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        renameClubQuestGroup(groupId: string, renameClubQuestGroupRequestDto: RenameClubQuestGroupRequestDto, options?: any): AxiosPromise<void> {
+            return localVarFp.renameClubQuestGroup(groupId, renameClubQuestGroupRequestDto, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -10345,6 +10425,19 @@ export class DefaultApi extends BaseAPI {
      */
     public notificationsPushSchedulesScheduleIdPut(scheduleId: string, adminUpdatePushNotificationScheduleRequestDTO: AdminUpdatePushNotificationScheduleRequestDTO, options?: AxiosRequestConfig) {
         return DefaultApiFp(this.configuration).notificationsPushSchedulesScheduleIdPut(scheduleId, adminUpdatePushNotificationScheduleRequestDTO, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary 퀘스트 그룹의 이름(퀘스트 이름 prefix)을 변경한다.
+     * @param {string} groupId 퀘스트 그룹 식별자
+     * @param {RenameClubQuestGroupRequestDto} renameClubQuestGroupRequestDto 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public renameClubQuestGroup(groupId: string, renameClubQuestGroupRequestDto: RenameClubQuestGroupRequestDto, options?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).renameClubQuestGroup(groupId, renameClubQuestGroupRequestDto, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
## Summary
- **장소 청크 관리**: 크롤 화면에 장소 검색 기능 추가 (카카오맵 Places API로 지도 이동)
- **퀘스트 이름 변경**: 퀘스트 관리에서 그룹 이름을 변경하는 Dialog UI 추가
- **그룹 헤더 표시**: 퀘스트 그룹 관리 화면 상단에 그룹 이름 표시

**Server PR**: https://github.com/Stair-Crusher-Club/scc-server/pull/914
**API Spec PR**: https://github.com/Stair-Crusher-Club/scc-api/pull/102

## Test plan
- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 통과 (기존 warning만 존재)
- [x] `pnpm build` 통과
- [x] Playwright E2E: 청크 크롤 페이지에서 "강남역" 검색 → 지도 이동 확인
- [x] Playwright E2E: 퀘스트 관리 페이지에서 "이름 변경" 버튼 → Dialog 표시 확인
- [x] Playwright E2E: 퀘스트 그룹 관리 페이지 상단 그룹 이름 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search functionality: Find locations with integrated map navigation, automatic map panning to results, and feedback notifications
  * Quest group enhancements: Display quest group name header and rename quest groups through a dedicated dialog interface
  * Improved feedback: Toast notifications for search outcomes and API operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->