### PR TITLE
feat: public 퀘스트 페이지에도 현위치 트래킹 버튼 및 방향 표시 추가

### DIFF
--- a/app/(public)/public/quest/[id]/page.tsx
+++ b/app/(public)/public/quest/[id]/page.tsx
@@ -12,9 +12,11 @@ import { ClubQuestTargetBuildingDTO } from "@/lib/generated-sources/openapi"
 import { storage } from "@/lib/storage"
 
 import Map from "@/components/Map"
-import { Me, QuestMarker } from "@/components/Map/components"
+import { Me, QuestMarker, LocationButton } from "@/components/Map/components"
 import { Contents } from "@/components/layout"
 import { PublicHeader } from "@/components/public-header"
+import useDeviceHeading from "@/hooks/useDeviceHeading"
+import useLocationTracking from "@/hooks/useLocationTracking"
 import { useModal } from "@/hooks/useModal"
 import QuestCompletionModal from "@/modals/QuestCompletion"
 
@@ -27,6 +29,15 @@ export default function QuestDetail() {
   const queryClient = useQueryClient()
   const [map, setMap] = useState<kakao.maps.Map>()
   const intialized = useRef(false)
+
+  const { heading, requestPermission } = useDeviceHeading()
+  const { trackingMode, position, toggleTracking, interruptTracking } = useLocationTracking({ map })
+
+  function handleLocationButtonClick() {
+    requestPermission()
+    toggleTracking()
+  }
+
   // 10초마다 퀘스트 진행 상황을 갱신합니다.
   useEffect(() => {
     const interval = setInterval(() => {
@@ -129,12 +140,23 @@ export default function QuestDetail() {
         </PublicHeader.ActionButtonWrapper>
       </PublicHeader>
       <Contents>
-        <Map id="map" initializeOptions={{ center: { lat: 37.566826, lng: 126.9786567 } }} onInit={setMap}>
-          {quest?.buildings.map((building, index) => (
-            <QuestMarker key={building.buildingId} building={building} questId={quest.id} buildingIndex={index} />
-          ))}
-          <Me />
-        </Map>
+        <div className="relative w-full h-full">
+          <Map id="map" initializeOptions={{ center: { lat: 37.566826, lng: 126.9786567 } }} onInit={setMap}>
+            {quest?.buildings.map((building, index) => (
+              <QuestMarker
+                key={building.buildingId}
+                building={building}
+                questId={quest.id}
+                buildingIndex={index}
+                onTrackingInterrupt={interruptTracking}
+              />
+            ))}
+            <Me position={position} heading={heading} />
+          </Map>
+          <div className="absolute z-10 bottom-4 right-4">
+            <LocationButton trackingMode={trackingMode} onClick={handleLocationButtonClick} />
+          </div>
+        </div>
       </Contents>
 
       <QuestCompletionModal


### PR DESCRIPTION
## Summary
- #119에서 private 퀘스트 페이지에만 적용했던 현위치 트래킹 + 방향 표시를 public 퀘스트 페이지에도 동일하게 적용

## Test plan
- [ ] https://admin.dev.staircrusher.club/public/quest/[id] 에서 현위치 버튼 표시 확인
- [ ] 버튼 클릭 → 현위치 추적 동작 확인
- [ ] 모바일에서 방향 부채꼴 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added location button (bottom-right corner) to control position tracking
  * Live user position and device heading now visible on quest maps
  * Enhanced marker interactions with tracking control options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->