### PR TITLE
fix: 현위치 마커 색상을 빨간색으로 복원

### DIFF
--- a/app/components/Map/components/Me.tsx
+++ b/app/components/Map/components/Me.tsx
@@ -28,19 +28,19 @@ export default function Me({ updateInterval = 1000, position: externalPosition, 
       cone.style.cssText = [
         "position: absolute; width: 80px; height: 80px; top: 50%; left: 50%;",
         "transform: translate(-50%, -50%);",
-        "background: conic-gradient(from -30deg, rgba(28, 100, 242, 0.35) 60deg, transparent 60deg);",
+        "background: conic-gradient(from -30deg, rgba(239, 68, 68, 0.35) 60deg, transparent 60deg);",
         "border-radius: 50%;",
         "display: none;",
       ].join(" ")
       container.appendChild(cone)
       coneRef.current = cone
 
-      // Accuracy ring (semi-transparent blue circle)
+      // Accuracy ring (semi-transparent red circle, matching me.png)
       const ring = document.createElement("div")
       ring.style.cssText = [
         "position: absolute; top: 50%; left: 50%;",
         "width: 36px; height: 36px;",
-        "background: rgba(28, 100, 242, 0.15);",
+        "background: rgba(239, 68, 68, 0.15);",
         "border-radius: 50%;",
         "transform: translate(-50%, -50%);",
       ].join(" ")
@@ -50,7 +50,7 @@ export default function Me({ updateInterval = 1000, position: externalPosition, 
       dot.style.cssText = [
         "position: absolute; top: 50%; left: 50%;",
         "width: 18px; height: 18px;",
-        "background: #1C64F2; border: 3px solid white; border-radius: 50%;",
+        "background: #EF4444; border: 3px solid white; border-radius: 50%;",
         "transform: translate(-50%, -50%);",
         "box-shadow: 0 0 6px rgba(0,0,0,0.35);",
       ].join(" ")


### PR DESCRIPTION
## Summary
- 기존 me.png가 빨간색이었는데 CustomOverlay 전환 시 파란색으로 잘못 변경됨
- 점, accuracy ring, 방향 부채꼴 모두 빨간색(#EF4444) 계열로 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)