### PR TITLE
feat: 퀘스트 상세 건물 바텀시트 화살표 네비 + focused 핀 강조

### DIFF
--- a/app/(private)/quest/[id]/page.tsx
+++ b/app/(private)/quest/[id]/page.tsx
@@ -19,6 +19,7 @@ export default function QuestDetail() {
   const { id } = useParams<{ id: string }>()
   const { data: quest } = useQuest({ id })
   const [map, setMap] = useState<kakao.maps.Map>()
+  const [focusedBuildingId, setFocusedBuildingId] = useState<string>()
   const { openModal } = useModal()
   const queryClient = useQueryClient()
   const intialized = useRef(false)
@@ -74,6 +75,9 @@ export default function QuestDetail() {
                 questId={quest.id}
                 buildingIndex={index}
                 onTrackingInterrupt={interruptTracking}
+                buildings={quest.buildings}
+                focusedBuildingId={focusedBuildingId}
+                onFocusChange={setFocusedBuildingId}
               />
             ))}
             <Me position={position} heading={heading} />

--- a/app/(public)/public/quest/[id]/page.tsx
+++ b/app/(public)/public/quest/[id]/page.tsx
@@ -28,6 +28,7 @@ export default function QuestDetail() {
   const { isHeaderHidden } = useAtomValue(AppState)
   const queryClient = useQueryClient()
   const [map, setMap] = useState<kakao.maps.Map>()
+  const [focusedBuildingId, setFocusedBuildingId] = useState<string>()
   const intialized = useRef(false)
 
   const { heading, requestPermission } = useDeviceHeading()
@@ -149,6 +150,9 @@ export default function QuestDetail() {
                 questId={quest.id}
                 buildingIndex={index}
                 onTrackingInterrupt={interruptTracking}
+                buildings={quest.buildings}
+                focusedBuildingId={focusedBuildingId}
+                onFocusChange={setFocusedBuildingId}
               />
             ))}
             <Me position={position} heading={heading} />

--- a/app/components/Map/components/QuestMarker.tsx
+++ b/app/components/Map/components/QuestMarker.tsx
@@ -15,91 +15,109 @@ export interface Props {
   questId: string
   markerStyle?: MarkerStyle
   onTrackingInterrupt?: () => void
+  buildings?: ClubQuestTargetBuildingDTO[]
+  focusedBuildingId?: string
+  onFocusChange?: (buildingId: string | undefined) => void
 }
 
-export default function QuestMarker({ building, buildingIndex, questId, markerStyle, onTrackingInterrupt }: Props) {
+const FOCUSED_SCALE = 1.5
+const FOCUSED_Z_INDEX = 999
+
+export default function QuestMarker({
+  building,
+  buildingIndex,
+  questId,
+  markerStyle,
+  onTrackingInterrupt,
+  buildings,
+  focusedBuildingId,
+  onFocusChange,
+}: Props) {
   const { map, mapElement } = useContext(MapContext)
-  const { openModal, closeModal, closeAll } = useModal()
+  const { openModal, closeAll } = useModal()
   const openedModal = useRef<string>()
   const isMobile = useMediaQuery({ maxWidth: 800 })
   const marker = useRef<kakao.maps.Marker>()
+
+  const isFocused = focusedBuildingId === building.buildingId
 
   useEffect(() => {
     if (!map) return
     if (!building) return
 
     const latlng = new kakao.maps.LatLng(building.location.lat, building.location.lng)
+    const scale = isFocused ? FOCUSED_SCALE : 1.0
 
-    const buildingIconIndex = building.name.match(/\d+번/) ? (parseInt(building.name.match(/(\d+)번/)![0]) - 1) : buildingIndex
+    const isAllConquered = building.places.every((p) => p.isConquered || p.isClosed || p.isNotAccessible)
 
-    const conqueredMarker = new kakao.maps.Marker({
-      position: latlng,
-      image: new kakao.maps.MarkerImage("/marker_conquered.png", new kakao.maps.Size(32, 32), {
-        offset: new kakao.maps.Point(8, 32),
-      }),
-    })
-    const notConqueredMarker = new kakao.maps.Marker({
-      position: latlng,
-      image: new kakao.maps.MarkerImage(`/marker_sprite.png`, new kakao.maps.Size(24, 36), {
-        offset: new kakao.maps.Point(12, 36),
-        spriteOrigin: new kakao.maps.Point(24 * (buildingIconIndex % 10), 36 * Math.floor(buildingIconIndex / 10)),
-        spriteSize: new kakao.maps.Size(24 * 10, 36 * 10),
-      }),
-    })
-    const buildingMarker = building.places.every((p) => p.isConquered || p.isClosed || p.isNotAccessible)
-      ? conqueredMarker
-      : notConqueredMarker
+    const image = isAllConquered
+      ? new kakao.maps.MarkerImage("/marker_conquered.png", new kakao.maps.Size(32 * scale, 32 * scale), {
+          offset: new kakao.maps.Point(8 * scale, 32 * scale),
+        })
+      : (() => {
+          const buildingIconIndex = building.name.match(/\d+번/)
+            ? parseInt(building.name.match(/(\d+)번/)![0]) - 1
+            : buildingIndex
+          return new kakao.maps.MarkerImage(`/marker_sprite.png`, new kakao.maps.Size(24 * scale, 36 * scale), {
+            offset: new kakao.maps.Point(12 * scale, 36 * scale),
+            spriteOrigin: new kakao.maps.Point(24 * scale * (buildingIconIndex % 10), 36 * scale * Math.floor(buildingIconIndex / 10)),
+            spriteSize: new kakao.maps.Size(24 * scale * 10, 36 * scale * 10),
+          })
+        })()
 
-    buildingMarker.setMap(map)
-    marker.current = buildingMarker
+    const m = new kakao.maps.Marker({ position: latlng, image })
+    m.setMap(map)
+    if (isFocused) m.setZIndex(FOCUSED_Z_INDEX)
+    marker.current = m
 
-    kakao.maps.event.addListener(marker.current, "click", () => onMarkerClick(building))
+    kakao.maps.event.addListener(m, "click", () => onMarkerClick(building))
 
-    // unmount 되면 map에서 circle을 제거.
     return () => {
-      marker.current?.setMap(null)
+      m.setMap(null)
     }
-  }, [map, building, markerStyle])
+  }, [map, building, buildingIndex, markerStyle, isFocused])
 
-  function onMarkerClick(building: ClubQuestTargetBuildingDTO) {
+  function onMarkerClick(target: ClubQuestTargetBuildingDTO) {
+    if (!map) return
+    onTrackingInterrupt?.()
+    openBuildingSheet(target)
+  }
+
+  function openBuildingSheet(target: ClubQuestTargetBuildingDTO) {
     if (!map) return
 
-    onTrackingInterrupt?.()
-
-    // 이미 열린 모달이 있다면 강제로 닫습니다.
     closeAll()
 
-    if (isMobile) {
-      // 지도 중앙에 마커를 위치시킵니다.
-      const focusPoint = getFocusedCenter(building)
-      map.panTo(focusPoint!)
+    onFocusChange?.(target.buildingId)
 
-      // 바텀시트를 엽니다.
-      openedModal.current = openModal({
-        type: "BuildingDetailSheetMobile",
-        props: { building, questId },
-        events: { onClose: () => onModalClose(building) },
-      })
-    } else {
-      // 지도 중앙에 마커를 위치시킵니다.
-      const focusPoint = getFocusedCenter(building)
-      map.panTo(focusPoint!)
+    const focusPoint = getFocusedCenter(target)
+    if (focusPoint) map.panTo(focusPoint)
 
-      // 우측에 시트를 엽니다.
-      openedModal.current = openModal({
-        type: "BuildingDetailSheetDesktop",
-        props: { building, questId },
-        events: { onClose: () => onModalClose(building) },
-      })
-    }
+    openedModal.current = openModal({
+      type: isMobile ? "BuildingDetailSheetMobile" : "BuildingDetailSheetDesktop",
+      props: {
+        building: target,
+        questId,
+        buildings,
+        onBuildingFocus: handleBuildingFocusChange,
+      },
+      events: { onClose: () => onModalClose(target) },
+    })
+  }
+
+  // 시트 내부에서 화살표로 건물을 바꿨을 때 부모 state + 카메라 동기화
+  function handleBuildingFocusChange(next: ClubQuestTargetBuildingDTO) {
+    if (!map) return
+    onFocusChange?.(next.buildingId)
+    const focusPoint = getFocusedCenter(next)
+    if (focusPoint) map.panTo(focusPoint)
   }
 
   function onModalClose(building: ClubQuestTargetBuildingDTO) {
-    // 모달이 닫히면 빌딩을 중앙으로 이동합니다
     const buildingCenter = new kakao.maps.LatLng(building.location.lat, building.location.lng)
     map?.panTo(buildingCenter)
-
     openedModal.current = undefined
+    onFocusChange?.(undefined)
   }
 
   /**

--- a/app/modals/BuildingDetailSheet/BuildingDetailSheet.desktop.tsx
+++ b/app/modals/BuildingDetailSheet/BuildingDetailSheet.desktop.tsx
@@ -17,12 +17,22 @@ import PlaceCard from "./PlaceCard"
 interface Props extends BasicModalProps {
   building: ClubQuestTargetBuildingDTO
   questId: string
+  buildings?: ClubQuestTargetBuildingDTO[]
+  onBuildingFocus?: (building: ClubQuestTargetBuildingDTO) => void
 }
 
 export const defaultOverlayOptions = { closeDelay: 200, dim: false }
-export default function BuildingDetailSheet({ building: initialData, questId, visible, close }: Props) {
+export default function BuildingDetailSheet({
+  building: initialData,
+  questId,
+  buildings,
+  onBuildingFocus,
+  visible,
+  close,
+}: Props) {
+  const [currentBuildingId, setCurrentBuildingId] = useState(initialData.buildingId)
   const [sortedPlaces, setSortedPlaces] = useState<ClubQuestTargetPlaceDTO[]>([])
-  const { data: building } = useQuestBuilding({ questId, buildingId: initialData.buildingId })
+  const { data: building } = useQuestBuilding({ questId, buildingId: currentBuildingId })
   const queryClient = useQueryClient()
   const [authenticated, setAuthenticated] = useState<boolean>()
   useEffect(() => {
@@ -59,7 +69,7 @@ export default function BuildingDetailSheet({ building: initialData, questId, vi
   // 활동 중 장소 순서가 바뀌는 것을 막습니다.
   useMemo(() => {
     setSortedPlaces(getSortedPlaces())
-  }, [initialData, building])
+  }, [currentBuildingId, building])
 
   // 다만 place가 삭제된 경우에만 장소를 다시 렌더링 해줍니다.
   useEffect(() => {
@@ -67,14 +77,40 @@ export default function BuildingDetailSheet({ building: initialData, questId, vi
     if (sortedPlaces.length !== newSortedPlaces.length) {
       setSortedPlaces(newSortedPlaces)
     }
-  }, [initialData, building])
+  }, [currentBuildingId, building])
+
+  const showNavButtons = !!buildings
+  function navigate(direction: -1 | 1) {
+    if (!buildings || buildings.length <= 1) return
+    const idx = buildings.findIndex((b) => b.buildingId === currentBuildingId)
+    if (idx === -1) return
+    const next = buildings[(idx + direction + buildings.length) % buildings.length]
+    setCurrentBuildingId(next.buildingId)
+    onBuildingFocus?.(next)
+  }
 
   if (!building) return null
 
   const conquered = building.places.filter(isConquered)
   const title = (
     <S.CustomTitle>
-      <h5>{building.name}</h5>
+      <S.TitleRow>
+        {showNavButtons && (
+          <S.NavButton type="button" aria-label="이전 건물" onClick={() => navigate(-1)}>
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12.5 15 7.5 10l5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </S.NavButton>
+        )}
+        <h5>{building.name}</h5>
+        {showNavButtons && (
+          <S.NavButton type="button" aria-label="다음 건물" onClick={() => navigate(1)}>
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="m7.5 5 5 5-5 5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </S.NavButton>
+        )}
+      </S.TitleRow>
       <S.ReloadButton onClick={reloadQuest}>
         <Reload size={24} />
       </S.ReloadButton>

--- a/app/modals/BuildingDetailSheet/BuildingDetailSheet.mobile.tsx
+++ b/app/modals/BuildingDetailSheet/BuildingDetailSheet.mobile.tsx
@@ -19,13 +19,23 @@ import PlaceCard from "./PlaceCard"
 interface Props extends BasicModalProps {
   building: ClubQuestTargetBuildingDTO
   questId: string
+  buildings?: ClubQuestTargetBuildingDTO[]
+  onBuildingFocus?: (building: ClubQuestTargetBuildingDTO) => void
 }
 
 export const defaultOverlayOptions = { closeDelay: 200, dim: false }
-export default function BuildingDetailSheet({ building: initialData, questId, visible, close }: Props) {
+export default function BuildingDetailSheet({
+  building: initialData,
+  questId,
+  buildings,
+  onBuildingFocus,
+  visible,
+  close,
+}: Props) {
+  const [currentBuildingId, setCurrentBuildingId] = useState(initialData.buildingId)
   const [sortedPlaces, setSortedPlaces] = useState<ClubQuestTargetPlaceDTO[]>([])
-  const { data: building } = useQuestBuilding({ questId, buildingId: initialData.buildingId })
-  const [appState, setAppState] = useAtom(AppState)
+  const { data: building } = useQuestBuilding({ questId, buildingId: currentBuildingId })
+  const [, setAppState] = useAtom(AppState)
   const queryClient = useQueryClient()
   const [authenticated, setAuthenticated] = useState<boolean>()
   useEffect(() => {
@@ -69,7 +79,7 @@ export default function BuildingDetailSheet({ building: initialData, questId, vi
   // 활동 중 장소 순서가 바뀌는 것을 막습니다.
   useMemo(() => {
     setSortedPlaces(getSortedPlaces())
-  }, [initialData, building])
+  }, [currentBuildingId, building])
 
   // 다만 place가 삭제된 경우에만 장소를 다시 렌더링 해줍니다.
   useEffect(() => {
@@ -77,14 +87,40 @@ export default function BuildingDetailSheet({ building: initialData, questId, vi
     if (sortedPlaces.length !== newSortedPlaces.length) {
       setSortedPlaces(newSortedPlaces)
     }
-  }, [initialData, building])
+  }, [currentBuildingId, building])
+
+  const showNavButtons = !!buildings
+  function navigate(direction: -1 | 1) {
+    if (!buildings || buildings.length <= 1) return
+    const idx = buildings.findIndex((b) => b.buildingId === currentBuildingId)
+    if (idx === -1) return
+    const next = buildings[(idx + direction + buildings.length) % buildings.length]
+    setCurrentBuildingId(next.buildingId)
+    onBuildingFocus?.(next)
+  }
 
   if (!building) return null
 
   const conquered = building.places.filter(isConquered)
   const title = (
     <S.CustomTitle>
-      <h5>{building.name}</h5>
+      <S.TitleRow>
+        {showNavButtons && (
+          <S.NavButton type="button" aria-label="이전 건물" onClick={() => navigate(-1)}>
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12.5 15 7.5 10l5-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </S.NavButton>
+        )}
+        <h5>{building.name}</h5>
+        {showNavButtons && (
+          <S.NavButton type="button" aria-label="다음 건물" onClick={() => navigate(1)}>
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="m7.5 5 5 5-5 5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </S.NavButton>
+        )}
+      </S.TitleRow>
       <S.ReloadButton onClick={reloadQuest}>
         <Reload size={24} />
       </S.ReloadButton>

--- a/app/modals/BuildingDetailSheet/BuildingDetailSheet.style.ts
+++ b/app/modals/BuildingDetailSheet/BuildingDetailSheet.style.ts
@@ -19,6 +19,38 @@ export const CustomTitle = styled("div", {
   },
 })
 
+export const TitleRow = styled("div", {
+  base: {
+    display: "flex",
+    flexFlow: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+  },
+})
+
+export const NavButton = styled("button", {
+  base: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 32,
+    height: 32,
+    padding: 0,
+    backgroundColor: "transparent",
+    border: "none",
+    cursor: "pointer",
+    borderRadius: "50%",
+    color: "var(--leaf-grey-30)",
+    "&:hover": {
+      backgroundColor: "rgba(0, 0, 0, 0.05)",
+    },
+    "&:active": {
+      backgroundColor: "rgba(0, 0, 0, 0.1)",
+    },
+  },
+})
+
 export const ReloadButton = styled("button", {
   base: {
     position: "absolute",


### PR DESCRIPTION
## Summary
- 어드민 퀘스트 상세(`/quest/[id]`)에서 건물 핀이 겹쳐 선택하기 어려운 문제를 해결하기 위해, 바텀시트 타이틀 좌우에 ‹ › 화살표 버튼을 추가해 이전/다음 건물로 이동할 수 있게 함
- 화살표 누르면 시트 내용 전환 + 지도 카메라가 해당 건물로 pan (기존 `getFocusedCenter` 오프셋 로직 재사용, 시트가 가리지 않는 영역 중앙으로 이동)
- 시트가 열려 있는(=focused) 건물 핀은 1.5배 확대 + z-index 최상단으로 올려, 겹친 핀 중 어떤 것이 선택됐는지 시각적으로 구분 가능

## 구현 디테일
- 시트는 자체 `useState`로 `currentBuildingId` 관리. 모달을 닫고 다시 열지 않고 `useQuestBuilding`이 새 ID로 재조회 → 시트 내용만 갱신 (깜빡임 없음)
- `QuestMarker`는 focused 여부에 따라 `kakao.maps.MarkerImage` 사이즈를 1.5배로 재생성 + `setZIndex(999)` 적용. focus state는 부모 페이지에서 `focusedBuildingId`로 소유해 여러 마커 간 동시 업데이트
- `/quest/[id]`와 `/public/quest/[id]` 양쪽에 동일하게 적용

## Test plan
- [ ] 건물이 5개 이상 있는 퀘스트 상세 열기
- [ ] 핀 클릭 → 바텀시트(모바일) / 우측시트(데스크탑) 열리고 해당 핀이 다른 핀보다 크게 + 위에 올라오는지
- [ ] ‹ › 화살표로 이전/다음 건물 이동 시 시트 내용 + 지도 카메라 이동 확인
- [ ] 마지막 건물에서 › 누르면 첫 건물로, 첫 건물에서 ‹ 누르면 마지막 건물로 wrap-around
- [ ] 시트 닫으면 모든 핀이 기본 크기로 복귀
- [ ] Reload/Delete 버튼 기존처럼 동작

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Building markers now highlight when selected on the quest map, with visual emphasis
- Added previous/next navigation buttons to browse through available buildings within the detail panel
- Map automatically pans to display newly focused buildings for improved visibility and navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->