### PR TITLE
feat: 퀘스트 상세 페이지에 장소 층 정보 표시 + 층별 정렬

### DIFF
--- a/app/modals/BuildingDetailSheet/BuildingDetailSheet.desktop.tsx
+++ b/app/modals/BuildingDetailSheet/BuildingDetailSheet.desktop.tsx
@@ -61,9 +61,16 @@ export default function BuildingDetailSheet({
 
   function getSortedPlaces() {
     if (!building) return []
-    const conquered = building.places.filter(isConquered).toSorted((a, b) => a.name.localeCompare(b.name))
-    const notConquered = building.places.filter((p) => !isConquered(p)).toSorted((a, b) => a.name.localeCompare(b.name))
-    return [...notConquered, ...conquered].map((p) => building.places.find((b) => b.placeId === p.placeId) || p)
+    const FLOOR_UNKNOWN = Number.POSITIVE_INFINITY
+    return [...building.places].sort((a, b) => {
+      const af = a.floorNum ?? FLOOR_UNKNOWN
+      const bf = b.floorNum ?? FLOOR_UNKNOWN
+      if (af !== bf) return af - bf
+      const ac = isConquered(a) ? 1 : 0
+      const bc = isConquered(b) ? 1 : 0
+      if (ac !== bc) return ac - bc
+      return a.name.localeCompare(b.name)
+    })
   }
 
   // 활동 중 장소 순서가 바뀌는 것을 막습니다.

--- a/app/modals/BuildingDetailSheet/BuildingDetailSheet.mobile.tsx
+++ b/app/modals/BuildingDetailSheet/BuildingDetailSheet.mobile.tsx
@@ -71,9 +71,16 @@ export default function BuildingDetailSheet({
 
   function getSortedPlaces() {
     if (!building) return []
-    const conquered = building.places.filter(isConquered).toSorted((a, b) => a.name.localeCompare(b.name))
-    const notConquered = building.places.filter((p) => !isConquered(p)).toSorted((a, b) => a.name.localeCompare(b.name))
-    return [...notConquered, ...conquered].map((p) => building.places.find((b) => b.placeId === p.placeId) || p)
+    const FLOOR_UNKNOWN = Number.POSITIVE_INFINITY
+    return [...building.places].sort((a, b) => {
+      const af = a.floorNum ?? FLOOR_UNKNOWN
+      const bf = b.floorNum ?? FLOOR_UNKNOWN
+      if (af !== bf) return af - bf
+      const ac = isConquered(a) ? 1 : 0
+      const bc = isConquered(b) ? 1 : 0
+      if (ac !== bc) return ac - bc
+      return a.name.localeCompare(b.name)
+    })
   }
 
   // 활동 중 장소 순서가 바뀌는 것을 막습니다.

--- a/app/modals/BuildingDetailSheet/PlaceCard.style.ts
+++ b/app/modals/BuildingDetailSheet/PlaceCard.style.ts
@@ -108,3 +108,13 @@ export const Link = styled("a", {
     cursor: "pointer",
   },
 })
+
+export const FloorInline = styled("span", {
+  base: {
+    fontSize: "13px",
+    color: "var(--leaf-grey-70)",
+    marginLeft: "4px",
+    whiteSpace: "nowrap",
+    flexShrink: 0,
+  },
+})

--- a/app/modals/BuildingDetailSheet/PlaceCard.tsx
+++ b/app/modals/BuildingDetailSheet/PlaceCard.tsx
@@ -14,6 +14,14 @@ import naverMapIcon from "../../../public/naver_map.jpg"
 import stairCrusherIcon from "../../../public/scc_button.png"
 import * as S from "./PlaceCard.style"
 
+function formatFloorLabel(place: ClubQuestTargetPlaceDTO): string {
+  if (place.floorNum != null) {
+    return place.floorNum < 0 ? `지하${-place.floorNum}층` : `${place.floorNum}층`
+  }
+  if (place.floor) return place.floor
+  return "층 없음"
+}
+
 interface Props {
   place: ClubQuestTargetPlaceDTO
   questId: string
@@ -98,6 +106,7 @@ export default function PlaceCard({ place, questId, onUpdate, onDelete }: Props)
         </S.Badges>
         <S.PlaceName>
           <span>{place.name}</span>
+          <S.FloorInline>({formatFloorLabel(place)})</S.FloorInline>
           <S.Button onClick={openInApp}>
             <Image src={stairCrusherIcon} alt="계단뿌셔클럽" style={{ width: 24, height: 24 }} />
           </S.Button>

--- a/lib/generated-sources/openapi/api.ts
+++ b/lib/generated-sources/openapi/api.ts
@@ -47,6 +47,37 @@ export interface AccessibilityAllowedRegionDTO {
     'boundaryVertices': Array<LocationDTO>;
 }
 /**
+ * 구조화된 신고 교정 데이터
+ * @export
+ * @interface AccessibilityReportCorrectionDTO
+ */
+export interface AccessibilityReportCorrectionDTO {
+    /**
+     * 
+     * @type {AdminPlaceAccessibilityCorrectionDTO}
+     * @memberof AccessibilityReportCorrectionDTO
+     */
+    'placeAccessibilityCorrection'?: AdminPlaceAccessibilityCorrectionDTO;
+    /**
+     * 
+     * @type {AdminBuildingAccessibilityCorrectionDTO}
+     * @memberof AccessibilityReportCorrectionDTO
+     */
+    'buildingAccessibilityCorrection'?: AdminBuildingAccessibilityCorrectionDTO;
+    /**
+     * 유저 부연 설명
+     * @type {string}
+     * @memberof AccessibilityReportCorrectionDTO
+     */
+    'noteText'?: string;
+    /**
+     * 유저 첨부 사진
+     * @type {Array<string>}
+     * @memberof AccessibilityReportCorrectionDTO
+     */
+    'photoUrls'?: Array<string>;
+}
+/**
  * 
  * @export
  * @enum {string}
@@ -293,6 +324,24 @@ export interface AdminAccessibilityReportDetailDTO {
      * @memberof AdminAccessibilityReportDetailDTO
      */
     'buildingAccessibility'?: AdminBuildingAccessibilityDTO;
+    /**
+     * 구조화 신고 - 틀린 정보 항목
+     * @type {Array<InaccurateInfoCategoryDTO>}
+     * @memberof AdminAccessibilityReportDetailDTO
+     */
+    'inaccurateCategories'?: Array<InaccurateInfoCategoryDTO>;
+    /**
+     * 
+     * @type {ClosedSubTypeDTO}
+     * @memberof AdminAccessibilityReportDetailDTO
+     */
+    'closedSubType'?: ClosedSubTypeDTO;
+    /**
+     * 
+     * @type {AccessibilityReportCorrectionDTO}
+     * @memberof AdminAccessibilityReportDetailDTO
+     */
+    'correction'?: AccessibilityReportCorrectionDTO;
 }
 /**
  * 
@@ -458,6 +507,61 @@ export interface AdminBannerDTO {
      * @memberof AdminBannerDTO
      */
     'bannerType': HomeBannerTypeDTO;
+}
+/**
+ * 유저가 제안한 건물 접근성 교정값
+ * @export
+ * @interface AdminBuildingAccessibilityCorrectionDTO
+ */
+export interface AdminBuildingAccessibilityCorrectionDTO {
+    /**
+     * 
+     * @type {AdminStairInfoDTO}
+     * @memberof AdminBuildingAccessibilityCorrectionDTO
+     */
+    'entranceStairInfo'?: AdminStairInfoDTO;
+    /**
+     * 
+     * @type {AdminStairHeightLevel}
+     * @memberof AdminBuildingAccessibilityCorrectionDTO
+     */
+    'entranceStairHeightLevel'?: AdminStairHeightLevel;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AdminBuildingAccessibilityCorrectionDTO
+     */
+    'hasSlope'?: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AdminBuildingAccessibilityCorrectionDTO
+     */
+    'hasElevator'?: boolean;
+    /**
+     * 
+     * @type {Array<AdminEntranceDoorType>}
+     * @memberof AdminBuildingAccessibilityCorrectionDTO
+     */
+    'entranceDoorTypes'?: Array<AdminEntranceDoorType>;
+    /**
+     * 
+     * @type {AdminStairInfoDTO}
+     * @memberof AdminBuildingAccessibilityCorrectionDTO
+     */
+    'elevatorStairInfo'?: AdminStairInfoDTO;
+    /**
+     * 
+     * @type {AdminStairHeightLevel}
+     * @memberof AdminBuildingAccessibilityCorrectionDTO
+     */
+    'elevatorStairHeightLevel'?: AdminStairHeightLevel;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AdminBuildingAccessibilityCorrectionDTO
+     */
+    'elevatorHasSlope'?: boolean;
 }
 /**
  * 
@@ -2111,6 +2215,43 @@ export interface AdminListPushNotificationSchedulesResponseDTO {
      * @memberof AdminListPushNotificationSchedulesResponseDTO
      */
     'cursor'?: string;
+}
+/**
+ * 유저가 제안한 장소 접근성 교정값
+ * @export
+ * @interface AdminPlaceAccessibilityCorrectionDTO
+ */
+export interface AdminPlaceAccessibilityCorrectionDTO {
+    /**
+     * 
+     * @type {AdminStairInfoDTO}
+     * @memberof AdminPlaceAccessibilityCorrectionDTO
+     */
+    'stairInfo'?: AdminStairInfoDTO;
+    /**
+     * 
+     * @type {AdminStairHeightLevel}
+     * @memberof AdminPlaceAccessibilityCorrectionDTO
+     */
+    'stairHeightLevel'?: AdminStairHeightLevel;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof AdminPlaceAccessibilityCorrectionDTO
+     */
+    'hasSlope'?: boolean;
+    /**
+     * 
+     * @type {Array<number>}
+     * @memberof AdminPlaceAccessibilityCorrectionDTO
+     */
+    'floors'?: Array<number>;
+    /**
+     * 
+     * @type {Array<AdminEntranceDoorType>}
+     * @memberof AdminPlaceAccessibilityCorrectionDTO
+     */
+    'entranceDoorTypes'?: Array<AdminEntranceDoorType>;
 }
 /**
  * 
@@ -3791,6 +3932,21 @@ export type ChallengeAggregationPeriodTypeEnum = typeof ChallengeAggregationPeri
 
 
 /**
+ * 폐업/이전 신고 시 세부 유형
+ * @export
+ * @enum {string}
+ */
+
+export const ClosedSubTypeDTO = {
+    PermanentlyClosed: 'PERMANENTLY_CLOSED',
+    ReplacedByOther: 'REPLACED_BY_OTHER',
+    Other: 'OTHER'
+} as const;
+
+export type ClosedSubTypeDTO = typeof ClosedSubTypeDTO[keyof typeof ClosedSubTypeDTO];
+
+
+/**
  * 퀘스트 생성 시뮬레이션 결과. 각 퀘스트마다 1개의 아이템이 반환된다.
  * @export
  * @interface ClubQuestCreateDryRunResultItemDTO
@@ -4040,6 +4196,18 @@ export interface ClubQuestTargetPlaceDTO {
      * @memberof ClubQuestTargetPlaceDTO
      */
     'isNotAccessible': boolean;
+    /**
+     * 점포가 위치한 층 표시용 문자열 원문. PlaceBusinessInfo.additionalInfo.floor 를 그대로 전달. 크롤링 미수집 또는 외부 소스에도 층 정보가 없으면 null.
+     * @type {string}
+     * @memberof ClubQuestTargetPlaceDTO
+     */
+    'floor'?: string;
+    /**
+     * 층 정규화 정수. 지상은 양수, 지하는 음수 (예: \"B1층\" → -1, \"3층\" → 3). 옥상/루프탑 등 정수로 환원 불가한 값 또는 크롤링 미수집 시 null. UI에서는 오름차순 정렬 키로 사용하고, null 은 유효 층 그룹 다음에 배치한다.
+     * @type {number}
+     * @memberof ClubQuestTargetPlaceDTO
+     */
+    'floorNum'?: number;
 }
 /**
  * 
@@ -4546,6 +4714,25 @@ export const HomeBannerTypeDTO = {
 } as const;
 
 export type HomeBannerTypeDTO = typeof HomeBannerTypeDTO[keyof typeof HomeBannerTypeDTO];
+
+
+/**
+ * 틀린 정보 신고 시 구체적으로 어떤 항목이 틀렸는지
+ * @export
+ * @enum {string}
+ */
+
+export const InaccurateInfoCategoryDTO = {
+    PlaceEntrance: 'PLACE_ENTRANCE',
+    Floor: 'FLOOR',
+    DoorType: 'DOOR_TYPE',
+    Elevator: 'ELEVATOR',
+    AccessLevel: 'ACCESS_LEVEL',
+    Photo: 'PHOTO',
+    Other: 'OTHER'
+} as const;
+
+export type InaccurateInfoCategoryDTO = typeof InaccurateInfoCategoryDTO[keyof typeof InaccurateInfoCategoryDTO];
 
 
 /**


### PR DESCRIPTION
## Summary

- BuildingDetailSheet 의 PlaceCard 장소 이름 옆에 `(1층)` / `(지하1층)` / `(옥상)` / `(층 없음)` 형태로 층 정보 인라인 노출
- places 정렬을 `floorNum` 오름차순 → 같은 층 내 정복 상태 → 이름 3단으로 교체. 같은 층에 있는 장소가 리스트 상에서 연속으로 묶여 노출된다.
- 같은 층 그룹 내에서 정복된 장소(isConquered || isNotAccessible || isClosed)가 그룹 하단에 배치됨

## Why

어드민 퀘스트 페이지에서 정복 대상 장소가 몇 층인지 보이지 않아 현장에서 장소를 찾기 어려운 문제. 크롤링된 `PlaceBusinessInfo.additionalInfo.{floor,floorNum}` 을 어드민에서 시각적으로 활용.

## Related

- scc-api: https://github.com/Stair-Crusher-Club/scc-api/pull/104
- scc-server: (병렬 PR 예정)

## Test plan

- [x] pnpm typecheck 통과
- [x] pnpm lint 통과
- [ ] 로컬에서 퀘스트 상세 페이지 bottom sheet 실제 렌더 확인 (데스크톱/모바일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Places now display floor information inline with their names for improved visibility.
  * Enhanced accessibility report system with new correction and categorization options.

* **Improvements**
  * Refined place sorting to organize by floor number first, then by status, and alphabetically within groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->