### PR TITLE
fix: 퀘스트 PlaceCard 층 라벨/정렬 조정

### DIFF
--- a/app/modals/BuildingDetailSheet/BuildingDetailSheet.desktop.tsx
+++ b/app/modals/BuildingDetailSheet/BuildingDetailSheet.desktop.tsx
@@ -61,7 +61,7 @@ export default function BuildingDetailSheet({
 
   function getSortedPlaces() {
     if (!building) return []
-    const FLOOR_UNKNOWN = Number.POSITIVE_INFINITY
+    const FLOOR_UNKNOWN = Number.NEGATIVE_INFINITY
     return [...building.places].sort((a, b) => {
       const af = a.floorNum ?? FLOOR_UNKNOWN
       const bf = b.floorNum ?? FLOOR_UNKNOWN

--- a/app/modals/BuildingDetailSheet/BuildingDetailSheet.mobile.tsx
+++ b/app/modals/BuildingDetailSheet/BuildingDetailSheet.mobile.tsx
@@ -71,7 +71,7 @@ export default function BuildingDetailSheet({
 
   function getSortedPlaces() {
     if (!building) return []
-    const FLOOR_UNKNOWN = Number.POSITIVE_INFINITY
+    const FLOOR_UNKNOWN = Number.NEGATIVE_INFINITY
     return [...building.places].sort((a, b) => {
       const af = a.floorNum ?? FLOOR_UNKNOWN
       const bf = b.floorNum ?? FLOOR_UNKNOWN

--- a/app/modals/BuildingDetailSheet/PlaceCard.tsx
+++ b/app/modals/BuildingDetailSheet/PlaceCard.tsx
@@ -19,7 +19,7 @@ function formatFloorLabel(place: ClubQuestTargetPlaceDTO): string {
     return place.floorNum < 0 ? `지하${-place.floorNum}층` : `${place.floorNum}층`
   }
   if (place.floor) return place.floor
-  return "층 없음"
+  return "층 모름"
 }
 
 interface Props {


### PR DESCRIPTION
## Summary

- '층 없음' → **'층 모름'** 라벨 변경 (데이터 부재가 아닌 모름이라는 의미)
- 층 모름 그룹 정렬 위치: 맨 뒤 → **맨 앞**

## Why

정복 시 층 정보를 모르는 장소가 가장 헷갈려서 우선 처리 대상. 맨 위로 보여서 빠르게 인지하도록.

## Files

- \`app/modals/BuildingDetailSheet/PlaceCard.tsx\` — formatFloorLabel 라벨 변경
- \`app/modals/BuildingDetailSheet/BuildingDetailSheet.{desktop,mobile}.tsx\` — getSortedPlaces FLOOR_UNKNOWN 상수를 POSITIVE_INFINITY → NEGATIVE_INFINITY

## Test plan

- [x] pnpm typecheck 통과
- [x] pnpm lint 통과 (신규 warning 0건)
- [ ] 어드민 dev에서 퀘스트 페이지 확인 (자동 배포 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Building places with unknown floor numbers now sort to the beginning of the list instead of the end.
  * Updated the display label for places with unknown floor information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->