### PR TITLE
fix: 퀘스트 PlaceCard 층 라벨 floorNum=0 fallback

### DIFF
--- a/app/modals/BuildingDetailSheet/PlaceCard.tsx
+++ b/app/modals/BuildingDetailSheet/PlaceCard.tsx
@@ -15,7 +15,7 @@ import stairCrusherIcon from "../../../public/scc_button.png"
 import * as S from "./PlaceCard.style"
 
 function formatFloorLabel(place: ClubQuestTargetPlaceDTO): string {
-  if (place.floorNum != null) {
+  if (place.floorNum != null && place.floorNum !== 0) {
     return place.floorNum < 0 ? `지하${-place.floorNum}층` : `${place.floorNum}층`
   }
   if (place.floor) return place.floor


### PR DESCRIPTION
## Summary
- floorNum이 0이면 LLM 정상화 실패로 추정되므로 \`(0층)\` 대신 원본 \`floor\` 문자열로 fallback
- floor도 없으면 기존처럼 \`층 모름\` 유지

## Why
어드민 퀘스트 페이지에서 \`(0층)\`으로 표기되는 케이스가 발견됨. 0층은 한국 건물 표기에 존재하지 않으므로, LLM이 \`floor\` 문자열을 \`floorNum\`으로 변환할 때 실패한 케이스로 보임. 이 경우 원본 \`floor\` 문자열을 보여주는 게 더 유용.

## Test plan
- [ ] dev 배포 후 어드민 퀘스트 페이지에서 \`(0층)\` 사라지는지 확인
- [ ] 정상 케이스(1층, 지하1층, 층 모름 등)는 그대로 표기되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected floor information handling in building detail cards. Floor numbers that are missing or not properly defined are now correctly displayed as unknown instead of being incorrectly formatted as numeric floor values. This improves accuracy of building information shown to users when reviewing place details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->