### PR TITLE
feat: B2B 챌린지 폼 필드별 isRequired 토글 UI

### DIFF
--- a/app/(private)/challenge/components/B2bFormSchemaPanel.tsx
+++ b/app/(private)/challenge/components/B2bFormSchemaPanel.tsx
@@ -11,6 +11,7 @@ interface B2bFormSchemaPanelProps {
   onUpdateField: (fieldId: string, updates: Partial<FormField>) => void
   onUpdateOptionsText: (fieldId: string, text: string) => void
   onToggleOptions: (fieldId: string, enabled: boolean) => void
+  onToggleRequired: (fieldId: string, isRequired: boolean) => void
   onAddCustomField: () => void
   onRemoveField: (fieldId: string) => void
   disabled?: boolean
@@ -23,6 +24,7 @@ export default function B2bFormSchemaPanel({
   onUpdateField,
   onUpdateOptionsText,
   onToggleOptions,
+  onToggleRequired,
   onAddCustomField,
   onRemoveField,
   disabled = false,
@@ -74,6 +76,7 @@ export default function B2bFormSchemaPanel({
                 onUpdateField={onUpdateField}
                 onUpdateOptionsText={onUpdateOptionsText}
                 onToggleOptions={onToggleOptions}
+                onToggleRequired={onToggleRequired}
                 disabled={disabled}
               />
             )
@@ -109,6 +112,7 @@ export default function B2bFormSchemaPanel({
               onRemove={onRemoveField}
               onUpdateOptionsText={onUpdateOptionsText}
               onToggleOptions={onToggleOptions}
+              onToggleRequired={onToggleRequired}
               disabled={disabled}
             />
           ))}

--- a/app/(private)/challenge/components/B2bFormTypes.ts
+++ b/app/(private)/challenge/components/B2bFormTypes.ts
@@ -17,6 +17,7 @@ export interface FormField {
   customDisplayName?: string    // Display name (built-in override or custom required)
   options: string[] | null      // Multiple choice options, null = free text
   optionsText: string          // UI input value (comma-separated)
+  isRequired: boolean          // 필수 입력 여부 (false면 선택 입력)
 }
 
 export interface BuiltinFieldOption {

--- a/app/(private)/challenge/components/BuiltinFieldItem.tsx
+++ b/app/(private)/challenge/components/BuiltinFieldItem.tsx
@@ -1,6 +1,7 @@
 import { AdminChallengeB2bFormSchemaAvailableFieldNameEnumDTO } from "@/lib/generated-sources/openapi"
 import { css } from "@/styles/css"
 import OptionsControl from "./OptionsControl"
+import RequiredControl from "./RequiredControl"
 import { FormField, BuiltinFieldOption } from "./B2bFormTypes"
 
 interface BuiltinFieldItemProps {
@@ -11,6 +12,7 @@ interface BuiltinFieldItemProps {
   onUpdateField: (fieldId: string, updates: Partial<FormField>) => void
   onUpdateOptionsText: (fieldId: string, text: string) => void
   onToggleOptions: (fieldId: string, enabled: boolean) => void
+  onToggleRequired: (fieldId: string, isRequired: boolean) => void
   disabled?: boolean
 }
 
@@ -22,6 +24,7 @@ export default function BuiltinFieldItem({
   onUpdateField,
   onUpdateOptionsText,
   onToggleOptions,
+  onToggleRequired,
   disabled = false,
 }: BuiltinFieldItemProps) {
   return (
@@ -103,6 +106,13 @@ export default function BuiltinFieldItem({
               })}
             />
           </div>
+
+          {/* Required Control */}
+          <RequiredControl
+            field={field}
+            onToggle={onToggleRequired}
+            disabled={disabled}
+          />
 
           {/* Options Control */}
           <OptionsControl

--- a/app/(private)/challenge/components/ChallengeForm.tsx
+++ b/app/(private)/challenge/components/ChallengeForm.tsx
@@ -127,9 +127,10 @@ function dtoToField(dto: AdminChallengeB2bFormSchemaAvailableFieldDTO): FormFiel
       customDisplayName: dto.customDisplayName || undefined,
       options: dto.options || null,
       optionsText: (dto.options || []).join(', '),
+      isRequired: dto.isRequired ?? true,
     }
   }
-  
+
   // V2 custom question (name === null, must have key and customDisplayName)
   return {
     id: generateId(),
@@ -138,6 +139,7 @@ function dtoToField(dto: AdminChallengeB2bFormSchemaAvailableFieldDTO): FormFiel
     customDisplayName: dto.customDisplayName || '',
     options: dto.options || null,
     optionsText: (dto.options || []).join(', '),
+    isRequired: dto.isRequired ?? true,
   }
 }
 
@@ -151,6 +153,7 @@ function fieldToDTO(field: FormField): AdminChallengeB2bFormSchemaAvailableField
       key: null,
       customDisplayName: field.customDisplayName || null,
       options: field.options || undefined,
+      isRequired: field.isRequired,
     }
   } else {
     // Custom field - omit name instead of setting to null
@@ -158,6 +161,7 @@ function fieldToDTO(field: FormField): AdminChallengeB2bFormSchemaAvailableField
       key: field.customKey!,
       customDisplayName: field.customDisplayName!,
       options: field.options || undefined,
+      isRequired: field.isRequired,
     }
   }
 }
@@ -212,6 +216,7 @@ export default function ChallengeForm({ form, id, isEditMode, onSubmit }: Props)
         customDisplayName: undefined,
         options: null,
         optionsText: '',
+        isRequired: true,
       }
       const newFields = [...formFields, newField]
       setFormFields(newFields)
@@ -260,6 +265,7 @@ export default function ChallengeForm({ form, id, isEditMode, onSubmit }: Props)
       customDisplayName: '',
       options: null,
       optionsText: '',
+      isRequired: true,
     }
     
     const newFields = [...formFields, newField]
@@ -284,6 +290,17 @@ export default function ChallengeForm({ form, id, isEditMode, onSubmit }: Props)
       field.id === fieldId
         ? { ...field, options: enabled ? [] : null, optionsText: enabled ? field.optionsText : '' }
         : field
+    )
+    setFormFields(newFields)
+    syncFormFieldsToSchema(newFields)
+  }
+
+  /**
+   * V2: Toggle required for a field
+   */
+  const handleToggleRequired = (fieldId: string, isRequired: boolean) => {
+    const newFields = formFields.map(field =>
+      field.id === fieldId ? { ...field, isRequired } : field
     )
     setFormFields(newFields)
     syncFormFieldsToSchema(newFields)
@@ -627,6 +644,7 @@ export default function ChallengeForm({ form, id, isEditMode, onSubmit }: Props)
               onUpdateField={handleUpdateField}
               onUpdateOptionsText={handleUpdateOptionsText}
               onToggleOptions={handleToggleOptions}
+              onToggleRequired={handleToggleRequired}
               onAddCustomField={handleAddCustomField}
               onRemoveField={handleRemoveField}
               disabled={isEditableFieldDisabled}

--- a/app/(private)/challenge/components/CustomFieldItem.tsx
+++ b/app/(private)/challenge/components/CustomFieldItem.tsx
@@ -1,5 +1,6 @@
 import { css } from "@/styles/css"
 import OptionsControl from "./OptionsControl"
+import RequiredControl from "./RequiredControl"
 import { FormField } from "./B2bFormTypes"
 
 interface CustomFieldItemProps {
@@ -9,6 +10,7 @@ interface CustomFieldItemProps {
   onRemove: (fieldId: string) => void
   onUpdateOptionsText: (fieldId: string, text: string) => void
   onToggleOptions: (fieldId: string, enabled: boolean) => void
+  onToggleRequired: (fieldId: string, isRequired: boolean) => void
   disabled?: boolean
 }
 
@@ -19,6 +21,7 @@ export default function CustomFieldItem({
   onRemove,
   onUpdateOptionsText,
   onToggleOptions,
+  onToggleRequired,
   disabled = false,
 }: CustomFieldItemProps) {
   return (
@@ -149,6 +152,13 @@ export default function CustomFieldItem({
             })}
           />
         </div>
+
+        {/* Required Control */}
+        <RequiredControl
+          field={field}
+          onToggle={onToggleRequired}
+          disabled={disabled}
+        />
 
         {/* Options Control */}
         <OptionsControl

--- a/app/(private)/challenge/components/RequiredControl.tsx
+++ b/app/(private)/challenge/components/RequiredControl.tsx
@@ -1,0 +1,34 @@
+import { css } from "@/styles/css"
+import { FormField } from "./B2bFormTypes"
+
+interface RequiredControlProps {
+  field: FormField
+  onToggle: (fieldId: string, isRequired: boolean) => void
+  disabled?: boolean
+}
+
+export default function RequiredControl({
+  field,
+  onToggle,
+  disabled = false,
+}: RequiredControlProps) {
+  return (
+    <label className={css({ display: "flex", alignItems: "center", gap: "6px", cursor: "pointer" })}>
+      <input
+        type="checkbox"
+        checked={field.isRequired}
+        onChange={(e) => onToggle(field.id, e.target.checked)}
+        disabled={disabled}
+        className={css({
+          width: "14px",
+          height: "14px",
+          cursor: "pointer",
+          _disabled: { cursor: "not-allowed" },
+        })}
+      />
+      <span className={css({ fontSize: "12px", color: "#374151" })}>
+        필수 입력 <span className={css({ color: "#9ca3af", fontSize: "11px" })}>(체크 해제 시 선택 입력)</span>
+      </span>
+    </label>
+  )
+}

--- a/lib/generated-sources/openapi/api.ts
+++ b/lib/generated-sources/openapi/api.ts
@@ -934,6 +934,12 @@ export interface AdminChallengeB2bFormSchemaAvailableFieldDTO {
      * @memberof AdminChallengeB2bFormSchemaAvailableFieldDTO
      */
     'options'?: Array<string> | null;
+    /**
+     * 필수 입력 여부 (null이면 true로 처리; 기존 필드 backward-compat)
+     * @type {boolean}
+     * @memberof AdminChallengeB2bFormSchemaAvailableFieldDTO
+     */
+    'isRequired'?: boolean | null;
 }
 /**
  * 


### PR DESCRIPTION
## Summary
- `FormField` 인터페이스에 `isRequired: boolean` 추가
- 신규 컴포넌트 `RequiredControl.tsx` — 체크박스로 필수/선택 토글
- `BuiltinFieldItem` / `CustomFieldItem`에 `RequiredControl` 렌더링
- `dtoToField`는 `dto.isRequired ?? true`로 backward-compat 보장; `fieldToDTO`는 항상 명시 전송
- 새 필드(builtin 토글 ON / custom 추가) 생성 시 기본 `isRequired: true`

## Why
운영자가 B2B 챌린지 폼 필드별로 필수/선택을 변경할 수 있도록.

## Dependencies
- scc-api PR: https://github.com/Stair-Crusher-Club/scc-api/pull/106
- scc-server PR: https://github.com/Stair-Crusher-Club/scc-server/pull/941
- 서브모듈 포인터: `feat/b2b-form-schema-required` (`85a5d9a`)

## Test plan
- [x] `pnpm panda` 통과
- [x] `pnpm typecheck` 통과 (에러 0)
- [x] `pnpm lint` 통과 (신규 경고 0)
- [ ] B2B 챌린지 생성/수정 페이지에서 필드 토글 동작 확인 (수동)
- [ ] 기존 챌린지(isRequired 미설정)를 열었을 때 모든 필드가 체크되어 표시되는지 확인 (수동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to toggle whether form fields are required or optional in B2B form builder.
  * Form requirement settings are now included in the form schema and persisted across sessions.
  * Both built-in and custom fields support the required/optional configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Stair-Crusher-Club/scc-admin/pull/131)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->