### PR TITLE
feat: PlaceList accessControl 필드 노출 (PRIVATE/PUBLIC/LINK_ONLY)

### DIFF
--- a/app/(private)/placeList/[id]/page.tsx
+++ b/app/(private)/placeList/[id]/page.tsx
@@ -4,7 +4,11 @@ import { useParams, useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
 import { toast } from "react-toastify"
 
-import { AdminPlaceListPlaceDto, AdminSearchedPlaceDto } from "@/lib/generated-sources/openapi"
+import {
+  AdminPlaceListAccessControlDto,
+  AdminPlaceListPlaceDto,
+  AdminSearchedPlaceDto,
+} from "@/lib/generated-sources/openapi"
 import {
   usePlaceListDetail,
   useUpdatePlaceList,
@@ -14,6 +18,8 @@ import {
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Contents } from "@/components/layout"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { ACCESS_CONTROL_LABELS, ACCESS_CONTROL_OPTIONS } from "../components/accessControl"
 import { PlaceSearchPanel } from "../components/PlaceSearchPanel"
 import { SortablePlaceList } from "../components/SortablePlaceList"
 
@@ -29,6 +35,9 @@ export default function PlaceListDetailPage() {
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
   const [iconColor, setIconColor] = useState("#FFC01E")
+  const [accessControl, setAccessControl] = useState<AdminPlaceListAccessControlDto>(
+    AdminPlaceListAccessControlDto.Public,
+  )
   const [places, setPlaces] = useState<AdminPlaceListPlaceDto[]>([])
 
   useEffect(() => {
@@ -36,6 +45,7 @@ export default function PlaceListDetailPage() {
       setName(placeList.name)
       setDescription(placeList.description ?? "")
       setIconColor(placeList.iconColor ?? "#FFC01E")
+      setAccessControl(placeList.accessControl)
       setPlaces(placeList.places)
     }
   }, [placeList])
@@ -48,6 +58,7 @@ export default function PlaceListDetailPage() {
           name,
           description: description || null,
           iconColor: iconColor || null,
+          accessControl,
           placeIds: places.map((p) => p.placeId),
         },
       })
@@ -143,6 +154,25 @@ export default function PlaceListDetailPage() {
                   placeholder="#FFC01E"
                 />
               </div>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">공개 설정</label>
+              <Select
+                value={accessControl}
+                onValueChange={(value) => setAccessControl(value as AdminPlaceListAccessControlDto)}
+              >
+                <SelectTrigger className="w-64">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ACCESS_CONTROL_OPTIONS.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {ACCESS_CONTROL_LABELS[option]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
           </CardContent>

--- a/app/(private)/placeList/components/accessControl.ts
+++ b/app/(private)/placeList/components/accessControl.ts
@@ -1,0 +1,26 @@
+import { AdminPlaceListAccessControlDto } from "@/lib/generated-sources/openapi"
+
+export const ACCESS_CONTROL_LABELS: Record<AdminPlaceListAccessControlDto, string> = {
+  [AdminPlaceListAccessControlDto.Private]: "비공개",
+  [AdminPlaceListAccessControlDto.Public]: "공개",
+  [AdminPlaceListAccessControlDto.LinkOnly]: "링크 있는 사람만",
+}
+
+export const ACCESS_CONTROL_OPTIONS: AdminPlaceListAccessControlDto[] = [
+  AdminPlaceListAccessControlDto.Public,
+  AdminPlaceListAccessControlDto.LinkOnly,
+  AdminPlaceListAccessControlDto.Private,
+]
+
+export function getAccessControlBadgeVariant(
+  accessControl: AdminPlaceListAccessControlDto,
+): "default" | "secondary" | "outline" {
+  switch (accessControl) {
+    case AdminPlaceListAccessControlDto.Public:
+      return "default"
+    case AdminPlaceListAccessControlDto.LinkOnly:
+      return "secondary"
+    case AdminPlaceListAccessControlDto.Private:
+      return "outline"
+  }
+}

--- a/app/(private)/placeList/components/columns.tsx
+++ b/app/(private)/placeList/components/columns.tsx
@@ -5,8 +5,10 @@ import { format } from "date-fns"
 
 import { AdminPlaceListDto } from "@/lib/generated-sources/openapi"
 
+import { Badge } from "@/components/ui/badge"
 import { DataTableColumnHeader } from "@/components/ui/data-table"
 
+import { ACCESS_CONTROL_LABELS, getAccessControlBadgeVariant } from "./accessControl"
 import { ActionsCell } from "./Cells"
 
 export const getColumns = (): ColumnDef<AdminPlaceListDto>[] => [
@@ -15,6 +17,18 @@ export const getColumns = (): ColumnDef<AdminPlaceListDto>[] => [
     header: ({ column }) => <DataTableColumnHeader column={column} title="이름" />,
     cell: ({ row }) => {
       return <div className="font-medium">{row.original.name}</div>
+    },
+  },
+  {
+    accessorKey: "accessControl",
+    header: "공개 설정",
+    cell: ({ row }) => {
+      const accessControl = row.original.accessControl
+      return (
+        <Badge variant={getAccessControlBadgeVariant(accessControl)}>
+          {ACCESS_CONTROL_LABELS[accessControl]}
+        </Badge>
+      )
     },
   },
   {

--- a/app/(private)/placeList/create/page.tsx
+++ b/app/(private)/placeList/create/page.tsx
@@ -4,12 +4,14 @@ import { useRouter } from "next/navigation"
 import { useState } from "react"
 import { toast } from "react-toastify"
 
-import { AdminSearchedPlaceDto } from "@/lib/generated-sources/openapi"
+import { AdminPlaceListAccessControlDto, AdminSearchedPlaceDto } from "@/lib/generated-sources/openapi"
 import { useCreatePlaceList } from "@/lib/apis/placeList"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Contents } from "@/components/layout"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { ACCESS_CONTROL_LABELS, ACCESS_CONTROL_OPTIONS } from "../components/accessControl"
 import { PlaceSearchPanel } from "../components/PlaceSearchPanel"
 import { SortablePlaceList } from "../components/SortablePlaceList"
 
@@ -20,6 +22,9 @@ export default function PlaceListCreatePage() {
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
   const [iconColor, setIconColor] = useState("#FFC01E")
+  const [accessControl, setAccessControl] = useState<AdminPlaceListAccessControlDto>(
+    AdminPlaceListAccessControlDto.Public,
+  )
   const [places, setPlaces] = useState<AdminSearchedPlaceDto[]>([])
 
   const handleCreate = async () => {
@@ -28,6 +33,7 @@ export default function PlaceListCreatePage() {
         name,
         description: description || null,
         iconColor: iconColor || null,
+        accessControl,
         placeIds: places.map((p) => p.placeId),
       })
       toast.success("리스트가 생성되었습니다.")
@@ -95,6 +101,25 @@ export default function PlaceListCreatePage() {
                   placeholder="#FFC01E"
                 />
               </div>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">공개 설정</label>
+              <Select
+                value={accessControl}
+                onValueChange={(value) => setAccessControl(value as AdminPlaceListAccessControlDto)}
+              >
+                <SelectTrigger className="w-64">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ACCESS_CONTROL_OPTIONS.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {ACCESS_CONTROL_LABELS[option]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
           </CardContent>

--- a/lib/generated-sources/openapi/api.ts
+++ b/lib/generated-sources/openapi/api.ts
@@ -934,12 +934,6 @@ export interface AdminChallengeB2bFormSchemaAvailableFieldDTO {
      * @memberof AdminChallengeB2bFormSchemaAvailableFieldDTO
      */
     'options'?: Array<string> | null;
-    /**
-     * 필수 입력 여부 (null이면 true로 처리; 기존 필드 backward-compat)
-     * @type {boolean}
-     * @memberof AdminChallengeB2bFormSchemaAvailableFieldDTO
-     */
-    'isRequired'?: boolean | null;
 }
 /**
  * 
@@ -1638,6 +1632,12 @@ export interface AdminCreatePlaceListRequestDto {
      * @memberof AdminCreatePlaceListRequestDto
      */
     'iconColor'?: string | null;
+    /**
+     * 
+     * @type {AdminPlaceListAccessControlDto}
+     * @memberof AdminCreatePlaceListRequestDto
+     */
+    'accessControl'?: AdminPlaceListAccessControlDto;
     /**
      * 리스트에 포함할 장소 ID 목록
      * @type {Array<string>}
@@ -2522,6 +2522,21 @@ export interface AdminPlaceCategoryCacheDto {
     'updatedAt': EpochMillisTimestamp;
 }
 /**
+ * 저장 리스트 접근 제어. Google Drive 파일 공유 모델을 모방한다. - PRIVATE: 본인만 접근 가능 (어드민에서 임의로 PRIVATE 리스트를 생성하지는 않으나, 호환을 위해 enum에 포함) - PUBLIC: 모든 사용자에게 공개 - LINK_ONLY: 튜토리얼 메인 미션을 모두 완료한 사용자에게만 노출 
+ * @export
+ * @enum {string}
+ */
+
+export const AdminPlaceListAccessControlDto = {
+    Private: 'PRIVATE',
+    Public: 'PUBLIC',
+    LinkOnly: 'LINK_ONLY'
+} as const;
+
+export type AdminPlaceListAccessControlDto = typeof AdminPlaceListAccessControlDto[keyof typeof AdminPlaceListAccessControlDto];
+
+
+/**
  * 저장 리스트 상세 정보 (장소 목록 포함)
  * @export
  * @interface AdminPlaceListDetailDto
@@ -2557,6 +2572,12 @@ export interface AdminPlaceListDetailDto {
      * @memberof AdminPlaceListDetailDto
      */
     'iconColor'?: string | null;
+    /**
+     * 
+     * @type {AdminPlaceListAccessControlDto}
+     * @memberof AdminPlaceListDetailDto
+     */
+    'accessControl': AdminPlaceListAccessControlDto;
     /**
      * 
      * @type {Array<AdminPlaceListPlaceDto>}
@@ -2618,6 +2639,12 @@ export interface AdminPlaceListDto {
      * @memberof AdminPlaceListDto
      */
     'placeCount': number;
+    /**
+     * 
+     * @type {AdminPlaceListAccessControlDto}
+     * @memberof AdminPlaceListDto
+     */
+    'accessControl': AdminPlaceListAccessControlDto;
     /**
      * 
      * @type {EpochMillisTimestamp}
@@ -3523,6 +3550,12 @@ export interface AdminUpdatePlaceListRequestDto {
      * @memberof AdminUpdatePlaceListRequestDto
      */
     'iconColor'?: string | null;
+    /**
+     * 
+     * @type {AdminPlaceListAccessControlDto}
+     * @memberof AdminUpdatePlaceListRequestDto
+     */
+    'accessControl'?: AdminPlaceListAccessControlDto;
     /**
      * 리스트에 포함할 장소 ID 목록 (기존 매핑을 대체)
      * @type {Array<string>}

--- a/lib/generated-sources/openapi/api.ts
+++ b/lib/generated-sources/openapi/api.ts
@@ -934,6 +934,12 @@ export interface AdminChallengeB2bFormSchemaAvailableFieldDTO {
      * @memberof AdminChallengeB2bFormSchemaAvailableFieldDTO
      */
     'options'?: Array<string> | null;
+    /**
+     * 필수 입력 여부 (null이면 true로 처리; 기존 필드 backward-compat)
+     * @type {boolean}
+     * @memberof AdminChallengeB2bFormSchemaAvailableFieldDTO
+     */
+    'isRequired'?: boolean | null;
 }
 /**
  * 


### PR DESCRIPTION
## Summary

- 윌리의 외출 NUX 튜토리얼 기능 도입에 따라 `PlaceList`에 추가된 `accessControl` 필드를 어드민 PlaceList CRUD에 노출
- 옵션: 공개 / 링크 있는 사람만 (LINK_ONLY) / 비공개 — Google Drive 식 공유 모델
- 생성 시 기본값 `PUBLIC`, 변경 시 select로 임의 변경 가능
- 목록 페이지에 "공개 설정" 컬럼 Badge 추가

## Related PRs

- scc-api: https://github.com/Stair-Crusher-Club/scc-api/pull/105
- scc-server: https://github.com/Stair-Crusher-Club/scc-server/pull/940

## Test plan

- [ ] 어드민에서 PlaceList 생성 시 accessControl 옵션이 보이는지 확인
- [ ] PlaceList 수정 시 현재 accessControl 값이 hydrate되는지 확인
- [ ] PlaceList 목록에서 각 row의 accessControl Badge가 정확히 표시되는지 확인
- [ ] LINK_ONLY로 설정한 PlaceList가 튜토리얼 완료 사용자 앱에서만 노출되는지 (서버측 동작 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Access control for place lists: Users can now set each place list as Private, Public, or Link Only when creating or editing lists to control sharing and access
  * Access control status displays with visual badges in the place list view for quick reference

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Stair-Crusher-Club/scc-admin/pull/132)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->