### PR TITLE
fix: 접근성 신고 어드민 화면에서 target 없는 신고(장소 자체) 표기

### DIFF
--- a/app/(private)/accessibilityReport/components/columns.tsx
+++ b/app/(private)/accessibilityReport/components/columns.tsx
@@ -47,7 +47,11 @@ export function getColumns({
       accessorKey: "targetType",
       header: "신고 유형",
       cell: ({ row }) => (
-        <div className="text-sm">{targetTypeLabels[row.original.targetType] ?? row.original.targetType}</div>
+        <div className="text-sm">
+          {row.original.targetType
+            ? (targetTypeLabels[row.original.targetType] ?? row.original.targetType)
+            : "장소 자체"}
+        </div>
       ),
     },
     {

--- a/app/modals/AccessibilityReportDetail/AccessibilityReportDetail.tsx
+++ b/app/modals/AccessibilityReportDetail/AccessibilityReportDetail.tsx
@@ -222,7 +222,11 @@ export default function AccessibilityReportDetail({ reportId, visible, close }: 
               <div className="text-muted-foreground">주소</div>
               <div>{detail.placeAddress ?? "-"}</div>
               <div className="text-muted-foreground">신고 유형</div>
-              <div>{targetTypeLabels[detail.targetType] ?? detail.targetType}</div>
+              <div>
+                {detail.targetType
+                  ? (targetTypeLabels[detail.targetType] ?? detail.targetType)
+                  : "장소 자체"}
+              </div>
               <div className="text-muted-foreground">신고 사유</div>
               <div>{reasonLabels[detail.reason] ?? detail.reason}</div>
               <div className="text-muted-foreground">상세 내용</div>

--- a/lib/generated-sources/openapi/api.ts
+++ b/lib/generated-sources/openapi/api.ts
@@ -245,13 +245,13 @@ export interface AdminAccessibilityReportDetailDTO {
      * @type {string}
      * @memberof AdminAccessibilityReportDetailDTO
      */
-    'targetId': string;
+    'targetId'?: string;
     /**
      * 
      * @type {ReportTargetTypeDTO}
      * @memberof AdminAccessibilityReportDetailDTO
      */
-    'targetType': ReportTargetTypeDTO;
+    'targetType'?: ReportTargetTypeDTO;
     /**
      * 
      * @type {AccessibilityReportReasonDTO}
@@ -360,7 +360,7 @@ export interface AdminAccessibilityReportListItemDTO {
      * @type {ReportTargetTypeDTO}
      * @memberof AdminAccessibilityReportListItemDTO
      */
-    'targetType': ReportTargetTypeDTO;
+    'targetType'?: ReportTargetTypeDTO;
     /**
      * 
      * @type {AccessibilityReportReasonDTO}
@@ -1639,6 +1639,12 @@ export interface AdminCreatePlaceListRequestDto {
      */
     'iconColor'?: string | null;
     /**
+     * 
+     * @type {AdminPlaceListAccessControlDto}
+     * @memberof AdminCreatePlaceListRequestDto
+     */
+    'accessControl'?: AdminPlaceListAccessControlDto;
+    /**
      * 리스트에 포함할 장소 ID 목록
      * @type {Array<string>}
      * @memberof AdminCreatePlaceListRequestDto
@@ -2522,6 +2528,21 @@ export interface AdminPlaceCategoryCacheDto {
     'updatedAt': EpochMillisTimestamp;
 }
 /**
+ * 저장 리스트 접근 제어. Google Drive 파일 공유 모델을 모방한다. - PRIVATE: 본인만 접근 가능 (어드민에서 임의로 PRIVATE 리스트를 생성하지는 않으나, 호환을 위해 enum에 포함) - PUBLIC: 모든 사용자에게 공개 - LINK_ONLY: 튜토리얼 메인 미션을 모두 완료한 사용자에게만 노출 
+ * @export
+ * @enum {string}
+ */
+
+export const AdminPlaceListAccessControlDto = {
+    Private: 'PRIVATE',
+    Public: 'PUBLIC',
+    LinkOnly: 'LINK_ONLY'
+} as const;
+
+export type AdminPlaceListAccessControlDto = typeof AdminPlaceListAccessControlDto[keyof typeof AdminPlaceListAccessControlDto];
+
+
+/**
  * 저장 리스트 상세 정보 (장소 목록 포함)
  * @export
  * @interface AdminPlaceListDetailDto
@@ -2557,6 +2578,12 @@ export interface AdminPlaceListDetailDto {
      * @memberof AdminPlaceListDetailDto
      */
     'iconColor'?: string | null;
+    /**
+     * 
+     * @type {AdminPlaceListAccessControlDto}
+     * @memberof AdminPlaceListDetailDto
+     */
+    'accessControl': AdminPlaceListAccessControlDto;
     /**
      * 
      * @type {Array<AdminPlaceListPlaceDto>}
@@ -2618,6 +2645,12 @@ export interface AdminPlaceListDto {
      * @memberof AdminPlaceListDto
      */
     'placeCount': number;
+    /**
+     * 
+     * @type {AdminPlaceListAccessControlDto}
+     * @memberof AdminPlaceListDto
+     */
+    'accessControl': AdminPlaceListAccessControlDto;
     /**
      * 
      * @type {EpochMillisTimestamp}
@@ -3523,6 +3556,12 @@ export interface AdminUpdatePlaceListRequestDto {
      * @memberof AdminUpdatePlaceListRequestDto
      */
     'iconColor'?: string | null;
+    /**
+     * 
+     * @type {AdminPlaceListAccessControlDto}
+     * @memberof AdminUpdatePlaceListRequestDto
+     */
+    'accessControl'?: AdminPlaceListAccessControlDto;
     /**
      * 리스트에 포함할 장소 ID 목록 (기존 매핑을 대체)
      * @type {Array<string>}


### PR DESCRIPTION
## Summary

scc-api 의 `AdminAccessibilityReport` DTO 에서 `targetId` / `targetType` 이 nullable 로 바뀜에 따라 codegen 결과 갱신 및 어드민 화면 nullable 처리.

## 변경

- `lib/generated-sources/openapi/api.ts`: codegen 결과 (`targetId?`, `targetType?`)
- `app/(private)/accessibilityReport/components/columns.tsx`: 목록의 신고 유형 셀, `targetType` 이 null 이면 "장소 자체"
- `app/modals/AccessibilityReportDetail/AccessibilityReportDetail.tsx`: 상세 모달도 동일
- `subprojects/scc-api`: submodule pointer 업데이트 (Stair-Crusher-Club/scc-api#108)

## 연관 PR

- scc-api: Stair-Crusher-Club/scc-api#108 (선행 머지 필요)
- scc-server: Stair-Crusher-Club/scc-server#TBD

## Test plan
- [x] `pnpm typecheck` 통과
- [ ] dev 어드민에서 PA 없는 폐업 신고 record 가 목록/상세에 "장소 자체" 로 표기되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access control options (Private, Public, Link Only) for place lists.

* **Bug Fixes**
  * Improved handling of missing target type information in accessibility reports with proper fallback display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Stair-Crusher-Club/scc-admin/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->