### PR TITLE
feat: 검색 플로우에서 저장리스트 노출 — 어드민

### DIFF
--- a/app/(private)/placeList/[id]/page.tsx
+++ b/app/(private)/placeList/[id]/page.tsx
@@ -33,6 +33,7 @@ export default function PlaceListDetailPage() {
   const { mutateAsync: deletePlaceList, isPending: isDeleting } = useDeletePlaceList()
 
   const [name, setName] = useState("")
+  const [shortName, setShortName] = useState("")
   const [description, setDescription] = useState("")
   const [iconColor, setIconColor] = useState("#FFC01E")
   const [accessControl, setAccessControl] = useState<AdminPlaceListAccessControlDto>(
@@ -43,6 +44,7 @@ export default function PlaceListDetailPage() {
   useEffect(() => {
     if (placeList) {
       setName(placeList.name)
+      setShortName(placeList.shortName ?? "")
       setDescription(placeList.description ?? "")
       setIconColor(placeList.iconColor ?? "#FFC01E")
       setAccessControl(placeList.accessControl)
@@ -56,6 +58,7 @@ export default function PlaceListDetailPage() {
         id: placeListId,
         data: {
           name,
+          shortName: shortName || null,
           description: description || null,
           iconColor: iconColor || null,
           accessControl,
@@ -124,6 +127,19 @@ export default function PlaceListDetailPage() {
                 onChange={(e) => setName(e.target.value)}
                 className="w-full px-3 py-2 border rounded-md"
                 placeholder="리스트 이름"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                짧은 이름 <span className="text-muted-foreground text-xs">(최대 8자, 검색 태그에 표시)</span>
+              </label>
+              <input
+                value={shortName}
+                onChange={(e) => setShortName(e.target.value)}
+                className="w-full px-3 py-2 border rounded-md"
+                placeholder="예: 홍대핫플"
+                maxLength={8}
               />
             </div>
 

--- a/app/(private)/placeList/components/columns.tsx
+++ b/app/(private)/placeList/components/columns.tsx
@@ -20,6 +20,17 @@ export const getColumns = (): ColumnDef<AdminPlaceListDto>[] => [
     },
   },
   {
+    accessorKey: "shortName",
+    header: "짧은 이름",
+    cell: ({ row }) => {
+      return (
+        <div className="text-sm text-muted-foreground">
+          {row.original.shortName ?? "-"}
+        </div>
+      )
+    },
+  },
+  {
     accessorKey: "accessControl",
     header: "공개 설정",
     cell: ({ row }) => {

--- a/app/(private)/placeList/create/page.tsx
+++ b/app/(private)/placeList/create/page.tsx
@@ -20,6 +20,7 @@ export default function PlaceListCreatePage() {
   const { mutateAsync: createPlaceList, isPending: isCreating } = useCreatePlaceList()
 
   const [name, setName] = useState("")
+  const [shortName, setShortName] = useState("")
   const [description, setDescription] = useState("")
   const [iconColor, setIconColor] = useState("#FFC01E")
   const [accessControl, setAccessControl] = useState<AdminPlaceListAccessControlDto>(
@@ -31,6 +32,7 @@ export default function PlaceListCreatePage() {
     try {
       await createPlaceList({
         name,
+        shortName: shortName || null,
         description: description || null,
         iconColor: iconColor || null,
         accessControl,
@@ -71,6 +73,19 @@ export default function PlaceListCreatePage() {
                 onChange={(e) => setName(e.target.value)}
                 className="w-full px-3 py-2 border rounded-md"
                 placeholder="리스트 이름"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                짧은 이름 <span className="text-muted-foreground text-xs">(최대 8자, 검색 태그에 표시)</span>
+              </label>
+              <input
+                value={shortName}
+                onChange={(e) => setShortName(e.target.value)}
+                className="w-full px-3 py-2 border rounded-md"
+                placeholder="예: 홍대핫플"
+                maxLength={8}
               />
             </div>
 

--- a/app/(private)/placeSearchRecommendation/create/page.tsx
+++ b/app/(private)/placeSearchRecommendation/create/page.tsx
@@ -63,14 +63,14 @@ export default function PlaceSearchRecommendationCreatePage() {
           <div className="space-y-2">
             <label className="text-sm font-medium">
               이름 <span className="text-red-500">*</span>
-              <span className="text-muted-foreground text-xs ml-1">(최대 12자, 칩에 표시)</span>
+              <span className="text-muted-foreground text-xs ml-1">(최대 8자, 칩에 표시)</span>
             </label>
             <input
               value={name}
               onChange={(e) => setName(e.target.value)}
               className="w-full px-3 py-2 border rounded-md"
               placeholder="예: 홍대 핫플"
-              maxLength={12}
+              maxLength={8}
             />
           </div>
 

--- a/app/(private)/placeSearchRecommendation/create/page.tsx
+++ b/app/(private)/placeSearchRecommendation/create/page.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import { toast } from "react-toastify"
+
+import {
+  AdminPlaceSearchRecommendationTypeDto,
+  AdminCreatePlaceSearchRecommendationRequestDto,
+} from "@/lib/generated-sources/openapi"
+import { useCreatePlaceSearchRecommendation } from "@/lib/apis/placeSearchRecommendation"
+import { usePlaceLists } from "@/lib/apis/placeList"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Contents } from "@/components/layout"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+export default function PlaceSearchRecommendationCreatePage() {
+  const router = useRouter()
+  const { mutateAsync: createRecommendation, isPending: isCreating } = useCreatePlaceSearchRecommendation()
+  const { data: placeLists } = usePlaceLists()
+
+  const [name, setName] = useState("")
+  const [placeListId, setPlaceListId] = useState("")
+  const [startAt, setStartAt] = useState("")
+  const [endAt, setEndAt] = useState("")
+
+  const handleCreate = async () => {
+    if (!placeListId) {
+      toast.error("저장리스트를 선택해주세요.")
+      return
+    }
+    try {
+      const payload: AdminCreatePlaceSearchRecommendationRequestDto = {
+        type: AdminPlaceSearchRecommendationTypeDto.RegionBased,
+        name,
+        placeListId,
+        startAt: startAt ? { value: new Date(startAt).getTime() } : undefined,
+        endAt: endAt ? { value: new Date(endAt).getTime() } : undefined,
+      }
+      await createRecommendation(payload)
+      toast.success("검색 추천이 생성되었습니다.")
+      router.push("/placeSearchRecommendation")
+    } catch {
+      toast.error("검색 추천 생성에 실패했습니다.")
+    }
+  }
+
+  return (
+    <Contents.Normal>
+      <Card>
+        <CardContent className="p-6 space-y-4">
+          <h3 className="text-lg font-semibold">검색 추천 추가</h3>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">타입</label>
+            <div className="px-3 py-2 border rounded-md bg-muted text-sm text-muted-foreground w-48">
+              지역 기반 (REGION_BASED)
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">
+              이름 <span className="text-red-500">*</span>
+              <span className="text-muted-foreground text-xs ml-1">(최대 12자, 칩에 표시)</span>
+            </label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full px-3 py-2 border rounded-md"
+              placeholder="예: 홍대 핫플"
+              maxLength={12}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">
+              저장리스트 <span className="text-red-500">*</span>
+            </label>
+            <Select value={placeListId} onValueChange={setPlaceListId}>
+              <SelectTrigger className="w-80">
+                <SelectValue placeholder="저장리스트 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {(placeLists ?? []).map((pl) => (
+                  <SelectItem key={pl.id} value={pl.id}>
+                    {pl.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              ⚠️ 장소 3개 이상 포함된 저장리스트를 선택해야 추천 영역(폴리곤)이 계산됩니다. 장소가 3개 미만이면 칩이 노출되지 않습니다.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">
+              노출 시작 <span className="text-muted-foreground text-xs">(비워두면 즉시 노출)</span>
+            </label>
+            <input
+              type="datetime-local"
+              value={startAt}
+              onChange={(e) => setStartAt(e.target.value)}
+              className="px-3 py-2 border rounded-md"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">
+              노출 종료 <span className="text-muted-foreground text-xs">(비워두면 무기한 노출)</span>
+            </label>
+            <input
+              type="datetime-local"
+              value={endAt}
+              onChange={(e) => setEndAt(e.target.value)}
+              className="px-3 py-2 border rounded-md"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-end gap-2 mt-6">
+        <Button
+          variant="outline"
+          onClick={() => router.push("/placeSearchRecommendation")}
+          disabled={isCreating}
+        >
+          취소
+        </Button>
+        <Button
+          onClick={handleCreate}
+          disabled={isCreating || !name.trim() || !placeListId}
+        >
+          {isCreating ? "생성 중..." : "생성"}
+        </Button>
+      </div>
+    </Contents.Normal>
+  )
+}

--- a/app/(private)/placeSearchRecommendation/create/page.tsx
+++ b/app/(private)/placeSearchRecommendation/create/page.tsx
@@ -91,7 +91,8 @@ export default function PlaceSearchRecommendationCreatePage() {
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">
-              ⚠️ 장소 3개 이상 포함된 저장리스트를 선택해야 추천 영역(폴리곤)이 계산됩니다. 장소가 3개 미만이면 칩이 노출되지 않습니다.
+              ⚠️ 장소 3개 이상 포함된 저장리스트를 선택해야 추천 영역(폴리곤)이
+              계산됩니다. 장소가 3개 미만이면 칩이 노출되지 않습니다.
             </p>
           </div>
 

--- a/app/(private)/placeSearchRecommendation/page.tsx
+++ b/app/(private)/placeSearchRecommendation/page.tsx
@@ -1,0 +1,271 @@
+"use client"
+
+import { format as formatDate } from "date-fns"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+import { toast } from "react-toastify"
+
+import {
+  AdminPlaceSearchRecommendationDto,
+  AdminPlaceSearchRecommendationTypeDto,
+  AdminUpdatePlaceSearchRecommendationRequestDto,
+} from "@/lib/generated-sources/openapi"
+import {
+  useDeletePlaceSearchRecommendation,
+  usePlaceSearchRecommendationsInfinite,
+  useUpdatePlaceSearchRecommendation,
+} from "@/lib/apis/placeSearchRecommendation"
+import { usePlaceLists } from "@/lib/apis/placeList"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Contents } from "@/components/layout"
+import { PageActions } from "@/components/page-actions"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+const dateFormat = "yyyy.MM.dd HH:mm"
+
+const TYPE_LABELS: Record<AdminPlaceSearchRecommendationTypeDto, string> = {
+  REGION_BASED: "지역 기반",
+}
+
+interface EditState {
+  id: string
+  name: string
+  placeListId: string
+  startAt: string
+  endAt: string
+}
+
+export default function PlaceSearchRecommendationPage() {
+  const router = useRouter()
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    usePlaceSearchRecommendationsInfinite()
+  const { data: placeLists } = usePlaceLists()
+  const { mutateAsync: updateRecommendation, isPending: isUpdating } = useUpdatePlaceSearchRecommendation()
+  const { mutateAsync: deleteRecommendation, isPending: isDeleting } = useDeletePlaceSearchRecommendation()
+
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editState, setEditState] = useState<EditState | null>(null)
+
+  const items = data?.pages.flatMap((page) => page.items) ?? []
+
+  const handleEdit = (item: AdminPlaceSearchRecommendationDto) => {
+    setEditingId(item.id)
+    setEditState({
+      id: item.id,
+      name: item.name,
+      placeListId: item.placeListId,
+      startAt: item.startAt ? formatDate(new Date(item.startAt.value), "yyyy-MM-dd'T'HH:mm") : "",
+      endAt: item.endAt ? formatDate(new Date(item.endAt.value), "yyyy-MM-dd'T'HH:mm") : "",
+    })
+  }
+
+  const handleSave = async () => {
+    if (!editState) return
+    try {
+      const payload: AdminUpdatePlaceSearchRecommendationRequestDto = {
+        type: AdminPlaceSearchRecommendationTypeDto.RegionBased,
+        name: editState.name,
+        placeListId: editState.placeListId,
+        startAt: editState.startAt ? { value: new Date(editState.startAt).getTime() } : undefined,
+        endAt: editState.endAt ? { value: new Date(editState.endAt).getTime() } : undefined,
+      }
+      await updateRecommendation({ id: editState.id, data: payload })
+      toast.success("검색 추천이 수정되었습니다.")
+      setEditingId(null)
+      setEditState(null)
+    } catch {
+      toast.error("검색 추천 수정에 실패했습니다.")
+    }
+  }
+
+  const handleCancelEdit = () => {
+    setEditingId(null)
+    setEditState(null)
+  }
+
+  const handleDelete = async (item: AdminPlaceSearchRecommendationDto) => {
+    if (!confirm(`정말 "${item.name}" 검색 추천을 삭제하시겠습니까?`)) {
+      return
+    }
+    try {
+      await deleteRecommendation(item.id)
+      toast.success("검색 추천이 삭제되었습니다.")
+    } catch {
+      toast.error("검색 추천 삭제에 실패했습니다.")
+    }
+  }
+
+  return (
+    <Contents.Normal>
+      <PageActions>
+        <Button onClick={() => router.push("/placeSearchRecommendation/create")} size="sm">
+          새 검색 추천 추가
+        </Button>
+      </PageActions>
+      <Card>
+        <CardContent className="p-6">
+          {isLoading ? (
+            <div className="text-center py-8">로딩 중...</div>
+          ) : (
+            <>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>이름</TableHead>
+                    <TableHead>저장리스트</TableHead>
+                    <TableHead>타입</TableHead>
+                    <TableHead>노출 시작</TableHead>
+                    <TableHead>노출 종료</TableHead>
+                    <TableHead>작업</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {items.map((item) => (
+                    <TableRow key={item.id}>
+                      {editingId === item.id && editState ? (
+                        <>
+                          <TableCell>
+                            <input
+                              value={editState.name}
+                              onChange={(e) => setEditState({ ...editState, name: e.target.value })}
+                              className="w-full px-2 py-1 border rounded-md text-sm"
+                              maxLength={12}
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <Select
+                              value={editState.placeListId}
+                              onValueChange={(value) => setEditState({ ...editState, placeListId: value })}
+                            >
+                              <SelectTrigger className="w-48 text-sm">
+                                <SelectValue placeholder="저장리스트 선택" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {(placeLists ?? []).map((pl) => (
+                                  <SelectItem key={pl.id} value={pl.id}>
+                                    {pl.name}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm text-muted-foreground">
+                              {TYPE_LABELS[item.type]}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <input
+                              type="datetime-local"
+                              value={editState.startAt}
+                              onChange={(e) => setEditState({ ...editState, startAt: e.target.value })}
+                              className="px-2 py-1 border rounded-md text-sm"
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <input
+                              type="datetime-local"
+                              value={editState.endAt}
+                              onChange={(e) => setEditState({ ...editState, endAt: e.target.value })}
+                              className="px-2 py-1 border rounded-md text-sm"
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex gap-2">
+                              <Button
+                                size="sm"
+                                onClick={handleSave}
+                                disabled={isUpdating || !editState.name.trim()}
+                              >
+                                저장
+                              </Button>
+                              <Button size="sm" variant="outline" onClick={handleCancelEdit}>
+                                취소
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </>
+                      ) : (
+                        <>
+                          <TableCell className="font-medium">{item.name}</TableCell>
+                          <TableCell>
+                            <span className="text-sm">
+                              {item.placeListName ?? item.placeListId}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm text-muted-foreground">
+                              {TYPE_LABELS[item.type]}
+                            </span>
+                          </TableCell>
+                          <TableCell className="text-sm whitespace-nowrap">
+                            {item.startAt
+                              ? formatDate(new Date(item.startAt.value), dateFormat)
+                              : "-"}
+                          </TableCell>
+                          <TableCell className="text-sm whitespace-nowrap">
+                            {item.endAt
+                              ? formatDate(new Date(item.endAt.value), dateFormat)
+                              : "-"}
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex gap-2">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => handleEdit(item)}
+                              >
+                                수정
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="destructive"
+                                onClick={() => handleDelete(item)}
+                                disabled={isDeleting}
+                              >
+                                삭제
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </>
+                      )}
+                    </TableRow>
+                  ))}
+                  {items.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={6} className="text-center text-muted-foreground">
+                        데이터가 없습니다.
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+              {hasNextPage && (
+                <div className="flex justify-center mt-4">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => fetchNextPage()}
+                    disabled={isFetchingNextPage}
+                  >
+                    {isFetchingNextPage ? "로딩 중..." : "더 보기"}
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </Contents.Normal>
+  )
+}

--- a/app/(private)/placeSearchRecommendation/page.tsx
+++ b/app/(private)/placeSearchRecommendation/page.tsx
@@ -139,7 +139,7 @@ export default function PlaceSearchRecommendationPage() {
                               value={editState.name}
                               onChange={(e) => setEditState({ ...editState, name: e.target.value })}
                               className="w-full px-2 py-1 border rounded-md text-sm"
-                              maxLength={12}
+                              maxLength={8}
                             />
                           </TableCell>
                           <TableCell>

--- a/app/components/layout/Sidebar.tsx
+++ b/app/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Megaphone,
   Search,
   ShieldCheck,
+  Star,
   Tag,
   Trophy,
 } from "lucide-react"
@@ -45,6 +46,7 @@ const menuItems = [
   { href: "/bbucleRoad", label: "뿌클로드 관리", icon: Map },
   { href: "/notification", label: "푸시 알림 관리", icon: Megaphone },
   { href: "/searchPreset", label: "추천 검색어 관리", icon: Search },
+  { href: "/placeSearchRecommendation", label: "검색 추천 관리", icon: Star },
   { href: "/accessibilityInspectionResult", label: "접근성 검증 결과", icon: ShieldCheck },
 ]
 

--- a/lib/apis/api.ts
+++ b/lib/apis/api.ts
@@ -36,6 +36,7 @@ import {
   PlaceAccessibilitySuggestionApi,
   PlaceCategoryCacheApi,
   PlaceListApi,
+  PlaceSearchRecommendationApi,
   PlaceSpecialAccessibilityApi,
 } from "../../lib/generated-sources/openapi"
 import {
@@ -67,6 +68,7 @@ const experimentApi = new ExperimentApi(config)
 const placeAccessibilitySuggestionApi = new PlaceAccessibilitySuggestionApi(config)
 const placeSpecialAccessibilityApi = new PlaceSpecialAccessibilityApi(config)
 const toiletApi = new AdminToiletApi(config)
+const placeSearchRecommendationApi = new PlaceSearchRecommendationApi(config)
 
 export const api: {
   default: DefaultApi
@@ -84,6 +86,7 @@ export const api: {
   placeAccessibilitySuggestion: PlaceAccessibilitySuggestionApi
   placeSpecialAccessibility: PlaceSpecialAccessibilityApi
   toilet: AdminToiletApi
+  placeSearchRecommendation: PlaceSearchRecommendationApi
 } = {
   default: defaultApi,
   challenge: challengeApi,
@@ -100,6 +103,7 @@ export const api: {
   placeAccessibilitySuggestion: placeAccessibilitySuggestionApi,
   placeSpecialAccessibility: placeSpecialAccessibilityApi,
   toilet: toiletApi,
+  placeSearchRecommendation: placeSearchRecommendationApi,
 }
 
 export function useQuest({ id }: { id: string }) {

--- a/lib/apis/placeSearchRecommendation.ts
+++ b/lib/apis/placeSearchRecommendation.ts
@@ -1,0 +1,83 @@
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+
+import {
+  AdminCreatePlaceSearchRecommendationRequestDto,
+  AdminPlaceSearchRecommendationDto,
+  AdminListPlaceSearchRecommendationsResponseDto,
+  AdminUpdatePlaceSearchRecommendationRequestDto,
+} from "@/lib/generated-sources/openapi"
+
+import { api } from "./api"
+
+// 검색 추천 목록 조회 (cursor pagination)
+export function usePlaceSearchRecommendationsInfinite(limit = 20) {
+  return useInfiniteQuery<AdminListPlaceSearchRecommendationsResponseDto>({
+    queryKey: ["@place-search-recommendations", limit],
+    queryFn: ({ pageParam }) =>
+      api.placeSearchRecommendation
+        .listPlaceSearchRecommendations((pageParam as string | undefined) ?? undefined, limit)
+        .then((res) => res.data),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.cursor ?? undefined,
+    staleTime: 10 * 1000,
+  })
+}
+
+// 검색 추천 생성
+export async function createPlaceSearchRecommendation(
+  data: AdminCreatePlaceSearchRecommendationRequestDto,
+): Promise<AdminPlaceSearchRecommendationDto> {
+  const result = await api.placeSearchRecommendation.createPlaceSearchRecommendation(data)
+  return result.data
+}
+
+// 검색 추천 생성 mutation hook
+export function useCreatePlaceSearchRecommendation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: createPlaceSearchRecommendation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["@place-search-recommendations"] })
+    },
+  })
+}
+
+// 검색 추천 수정
+export async function updatePlaceSearchRecommendation(
+  id: string,
+  data: AdminUpdatePlaceSearchRecommendationRequestDto,
+): Promise<AdminPlaceSearchRecommendationDto> {
+  const result = await api.placeSearchRecommendation.updatePlaceSearchRecommendation(id, data)
+  return result.data
+}
+
+// 검색 추천 수정 mutation hook
+export function useUpdatePlaceSearchRecommendation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: AdminUpdatePlaceSearchRecommendationRequestDto }) =>
+      updatePlaceSearchRecommendation(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["@place-search-recommendations"] })
+    },
+  })
+}
+
+// 검색 추천 삭제
+export async function deletePlaceSearchRecommendation(id: string): Promise<void> {
+  await api.placeSearchRecommendation.deletePlaceSearchRecommendation(id)
+}
+
+// 검색 추천 삭제 mutation hook
+export function useDeletePlaceSearchRecommendation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: deletePlaceSearchRecommendation,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["@place-search-recommendations"] })
+    },
+  })
+}

--- a/lib/generated-sources/openapi/api.ts
+++ b/lib/generated-sources/openapi/api.ts
@@ -1621,6 +1621,12 @@ export interface AdminCreatePlaceListRequestDto {
      */
     'name': string;
     /**
+     * 검색 결과 카드 등 공간이 좁은 곳에 표시하는 짧은 이름 (최대 8자).
+     * @type {string}
+     * @memberof AdminCreatePlaceListRequestDto
+     */
+    'shortName'?: string | null;
+    /**
      * 
      * @type {string}
      * @memberof AdminCreatePlaceListRequestDto
@@ -1650,6 +1656,43 @@ export interface AdminCreatePlaceListRequestDto {
      * @memberof AdminCreatePlaceListRequestDto
      */
     'placeIds': Array<string>;
+}
+/**
+ * 장소 검색 추천 생성 요청
+ * @export
+ * @interface AdminCreatePlaceSearchRecommendationRequestDto
+ */
+export interface AdminCreatePlaceSearchRecommendationRequestDto {
+    /**
+     * 
+     * @type {AdminPlaceSearchRecommendationTypeDto}
+     * @memberof AdminCreatePlaceSearchRecommendationRequestDto
+     */
+    'type': AdminPlaceSearchRecommendationTypeDto;
+    /**
+     * 칩에 표시하는 짧은 이름 (최대 12자)
+     * @type {string}
+     * @memberof AdminCreatePlaceSearchRecommendationRequestDto
+     */
+    'name': string;
+    /**
+     * 연결할 저장리스트 ID
+     * @type {string}
+     * @memberof AdminCreatePlaceSearchRecommendationRequestDto
+     */
+    'placeListId': string;
+    /**
+     * 
+     * @type {EpochMillisTimestamp}
+     * @memberof AdminCreatePlaceSearchRecommendationRequestDto
+     */
+    'startAt'?: EpochMillisTimestamp;
+    /**
+     * 
+     * @type {EpochMillisTimestamp}
+     * @memberof AdminCreatePlaceSearchRecommendationRequestDto
+     */
+    'endAt'?: EpochMillisTimestamp;
 }
 /**
  * 
@@ -2210,6 +2253,25 @@ export interface AdminListPlaceListsResponseDto {
     'cursor'?: string | null;
 }
 /**
+ * 장소 검색 추천 목록 응답
+ * @export
+ * @interface AdminListPlaceSearchRecommendationsResponseDto
+ */
+export interface AdminListPlaceSearchRecommendationsResponseDto {
+    /**
+     * 
+     * @type {Array<AdminPlaceSearchRecommendationDto>}
+     * @memberof AdminListPlaceSearchRecommendationsResponseDto
+     */
+    'items': Array<AdminPlaceSearchRecommendationDto>;
+    /**
+     * 다음 페이지 커서 (없으면 마지막 페이지)
+     * @type {string}
+     * @memberof AdminListPlaceSearchRecommendationsResponseDto
+     */
+    'cursor'?: string | null;
+}
+/**
  * 
  * @export
  * @interface AdminListPushNotificationSchedulesResponseDTO
@@ -2561,6 +2623,12 @@ export interface AdminPlaceListDetailDto {
      */
     'name': string;
     /**
+     * 검색 결과 카드 등 공간이 좁은 곳에 표시하는 짧은 이름 (최대 8자).
+     * @type {string}
+     * @memberof AdminPlaceListDetailDto
+     */
+    'shortName'?: string | null;
+    /**
      * 
      * @type {string}
      * @memberof AdminPlaceListDetailDto
@@ -2621,6 +2689,12 @@ export interface AdminPlaceListDto {
      * @memberof AdminPlaceListDto
      */
     'name': string;
+    /**
+     * 검색 결과 카드 등 공간이 좁은 곳에 표시하는 짧은 이름 (최대 8자).
+     * @type {string}
+     * @memberof AdminPlaceListDto
+     */
+    'shortName'?: string | null;
     /**
      * 
      * @type {string}
@@ -2701,6 +2775,80 @@ export interface AdminPlaceListPlaceDto {
      */
     'accessibilityScore'?: number | null;
 }
+/**
+ * 장소 검색 추천 항목
+ * @export
+ * @interface AdminPlaceSearchRecommendationDto
+ */
+export interface AdminPlaceSearchRecommendationDto {
+    /**
+     * 
+     * @type {string}
+     * @memberof AdminPlaceSearchRecommendationDto
+     */
+    'id': string;
+    /**
+     * 
+     * @type {AdminPlaceSearchRecommendationTypeDto}
+     * @memberof AdminPlaceSearchRecommendationDto
+     */
+    'type': AdminPlaceSearchRecommendationTypeDto;
+    /**
+     * 칩에 표시하는 짧은 이름
+     * @type {string}
+     * @memberof AdminPlaceSearchRecommendationDto
+     */
+    'name': string;
+    /**
+     * 연결된 저장리스트 ID
+     * @type {string}
+     * @memberof AdminPlaceSearchRecommendationDto
+     */
+    'placeListId': string;
+    /**
+     * 연결된 저장리스트 이름 (표시용)
+     * @type {string}
+     * @memberof AdminPlaceSearchRecommendationDto
+     */
+    'placeListName'?: string | null;
+    /**
+     * 
+     * @type {EpochMillisTimestamp}
+     * @memberof AdminPlaceSearchRecommendationDto
+     */
+    'startAt'?: EpochMillisTimestamp;
+    /**
+     * 
+     * @type {EpochMillisTimestamp}
+     * @memberof AdminPlaceSearchRecommendationDto
+     */
+    'endAt'?: EpochMillisTimestamp;
+    /**
+     * 
+     * @type {EpochMillisTimestamp}
+     * @memberof AdminPlaceSearchRecommendationDto
+     */
+    'createdAt': EpochMillisTimestamp;
+    /**
+     * 
+     * @type {EpochMillisTimestamp}
+     * @memberof AdminPlaceSearchRecommendationDto
+     */
+    'updatedAt': EpochMillisTimestamp;
+}
+/**
+ * 장소 검색 추천 타입
+ * @export
+ * @enum {string}
+ */
+
+export const AdminPlaceSearchRecommendationTypeDto = {
+    RegionBased: 'REGION_BASED'
+} as const;
+
+export type AdminPlaceSearchRecommendationTypeDto = typeof AdminPlaceSearchRecommendationTypeDto[keyof typeof AdminPlaceSearchRecommendationTypeDto];
+
+
 /**
  * 뿌클로드 접근성 데이터 (어드민용)
  * @export
@@ -3748,6 +3896,12 @@ export interface AdminUpdatePlaceListRequestDto {
      */
     'name': string;
     /**
+     * 검색 결과 카드 등 공간이 좁은 곳에 표시하는 짧은 이름 (최대 8자).
+     * @type {string}
+     * @memberof AdminUpdatePlaceListRequestDto
+     */
+    'shortName'?: string | null;
+    /**
      * 
      * @type {string}
      * @memberof AdminUpdatePlaceListRequestDto
@@ -3777,6 +3931,43 @@ export interface AdminUpdatePlaceListRequestDto {
      * @memberof AdminUpdatePlaceListRequestDto
      */
     'placeIds': Array<string>;
+}
+/**
+ * 장소 검색 추천 수정 요청
+ * @export
+ * @interface AdminUpdatePlaceSearchRecommendationRequestDto
+ */
+export interface AdminUpdatePlaceSearchRecommendationRequestDto {
+    /**
+     * 
+     * @type {AdminPlaceSearchRecommendationTypeDto}
+     * @memberof AdminUpdatePlaceSearchRecommendationRequestDto
+     */
+    'type': AdminPlaceSearchRecommendationTypeDto;
+    /**
+     * 칩에 표시하는 짧은 이름 (최대 12자)
+     * @type {string}
+     * @memberof AdminUpdatePlaceSearchRecommendationRequestDto
+     */
+    'name': string;
+    /**
+     * 연결할 저장리스트 ID
+     * @type {string}
+     * @memberof AdminUpdatePlaceSearchRecommendationRequestDto
+     */
+    'placeListId': string;
+    /**
+     * 
+     * @type {EpochMillisTimestamp}
+     * @memberof AdminUpdatePlaceSearchRecommendationRequestDto
+     */
+    'startAt'?: EpochMillisTimestamp;
+    /**
+     * 
+     * @type {EpochMillisTimestamp}
+     * @memberof AdminUpdatePlaceSearchRecommendationRequestDto
+     */
+    'endAt'?: EpochMillisTimestamp;
 }
 /**
  * 
@@ -13652,6 +13843,348 @@ export class PlaceListApi extends BaseAPI {
      */
     public updatePlaceList(id: string, adminUpdatePlaceListRequestDto: AdminUpdatePlaceListRequestDto, options?: AxiosRequestConfig) {
         return PlaceListApiFp(this.configuration).updatePlaceList(id, adminUpdatePlaceListRequestDto, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+/**
+ * PlaceSearchRecommendationApi - axios parameter creator
+ * @export
+ */
+export const PlaceSearchRecommendationApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * 
+         * @summary 장소 검색 추천을 생성한다.
+         * @param {AdminCreatePlaceSearchRecommendationRequestDto} adminCreatePlaceSearchRecommendationRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createPlaceSearchRecommendation: async (adminCreatePlaceSearchRecommendationRequestDto: AdminCreatePlaceSearchRecommendationRequestDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'adminCreatePlaceSearchRecommendationRequestDto' is not null or undefined
+            assertParamExists('createPlaceSearchRecommendation', 'adminCreatePlaceSearchRecommendationRequestDto', adminCreatePlaceSearchRecommendationRequestDto)
+            const localVarPath = `/place-search-recommendations`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Admin required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(adminCreatePlaceSearchRecommendationRequestDto, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary 장소 검색 추천을 삭제한다.
+         * @param {string} id PlaceSearchRecommendation ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        deletePlaceSearchRecommendation: async (id: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('deletePlaceSearchRecommendation', 'id', id)
+            const localVarPath = `/place-search-recommendations/{id}`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Admin required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary 장소 검색 추천 목록을 조회한다.
+         * @param {string} [cursor] 페이지네이션 커서
+         * @param {number} [limit] 페이지당 항목 수 (기본값 20)
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listPlaceSearchRecommendations: async (cursor?: string, limit?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/place-search-recommendations`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Admin required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (cursor !== undefined) {
+                localVarQueryParameter['cursor'] = cursor;
+            }
+
+            if (limit !== undefined) {
+                localVarQueryParameter['limit'] = limit;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary 장소 검색 추천을 수정한다.
+         * @param {string} id PlaceSearchRecommendation ID
+         * @param {AdminUpdatePlaceSearchRecommendationRequestDto} adminUpdatePlaceSearchRecommendationRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updatePlaceSearchRecommendation: async (id: string, adminUpdatePlaceSearchRecommendationRequestDto: AdminUpdatePlaceSearchRecommendationRequestDto, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('updatePlaceSearchRecommendation', 'id', id)
+            // verify required parameter 'adminUpdatePlaceSearchRecommendationRequestDto' is not null or undefined
+            assertParamExists('updatePlaceSearchRecommendation', 'adminUpdatePlaceSearchRecommendationRequestDto', adminUpdatePlaceSearchRecommendationRequestDto)
+            const localVarPath = `/place-search-recommendations/{id}`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication Admin required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(adminUpdatePlaceSearchRecommendationRequestDto, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * PlaceSearchRecommendationApi - functional programming interface
+ * @export
+ */
+export const PlaceSearchRecommendationApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = PlaceSearchRecommendationApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * 
+         * @summary 장소 검색 추천을 생성한다.
+         * @param {AdminCreatePlaceSearchRecommendationRequestDto} adminCreatePlaceSearchRecommendationRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async createPlaceSearchRecommendation(adminCreatePlaceSearchRecommendationRequestDto: AdminCreatePlaceSearchRecommendationRequestDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AdminPlaceSearchRecommendationDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createPlaceSearchRecommendation(adminCreatePlaceSearchRecommendationRequestDto, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
+         * @summary 장소 검색 추천을 삭제한다.
+         * @param {string} id PlaceSearchRecommendation ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async deletePlaceSearchRecommendation(id: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePlaceSearchRecommendation(id, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
+         * @summary 장소 검색 추천 목록을 조회한다.
+         * @param {string} [cursor] 페이지네이션 커서
+         * @param {number} [limit] 페이지당 항목 수 (기본값 20)
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async listPlaceSearchRecommendations(cursor?: string, limit?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AdminListPlaceSearchRecommendationsResponseDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listPlaceSearchRecommendations(cursor, limit, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
+         * @summary 장소 검색 추천을 수정한다.
+         * @param {string} id PlaceSearchRecommendation ID
+         * @param {AdminUpdatePlaceSearchRecommendationRequestDto} adminUpdatePlaceSearchRecommendationRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async updatePlaceSearchRecommendation(id: string, adminUpdatePlaceSearchRecommendationRequestDto: AdminUpdatePlaceSearchRecommendationRequestDto, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AdminPlaceSearchRecommendationDto>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updatePlaceSearchRecommendation(id, adminUpdatePlaceSearchRecommendationRequestDto, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+    }
+};
+
+/**
+ * PlaceSearchRecommendationApi - factory interface
+ * @export
+ */
+export const PlaceSearchRecommendationApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = PlaceSearchRecommendationApiFp(configuration)
+    return {
+        /**
+         * 
+         * @summary 장소 검색 추천을 생성한다.
+         * @param {AdminCreatePlaceSearchRecommendationRequestDto} adminCreatePlaceSearchRecommendationRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createPlaceSearchRecommendation(adminCreatePlaceSearchRecommendationRequestDto: AdminCreatePlaceSearchRecommendationRequestDto, options?: any): AxiosPromise<AdminPlaceSearchRecommendationDto> {
+            return localVarFp.createPlaceSearchRecommendation(adminCreatePlaceSearchRecommendationRequestDto, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary 장소 검색 추천을 삭제한다.
+         * @param {string} id PlaceSearchRecommendation ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        deletePlaceSearchRecommendation(id: string, options?: any): AxiosPromise<void> {
+            return localVarFp.deletePlaceSearchRecommendation(id, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary 장소 검색 추천 목록을 조회한다.
+         * @param {string} [cursor] 페이지네이션 커서
+         * @param {number} [limit] 페이지당 항목 수 (기본값 20)
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        listPlaceSearchRecommendations(cursor?: string, limit?: number, options?: any): AxiosPromise<AdminListPlaceSearchRecommendationsResponseDto> {
+            return localVarFp.listPlaceSearchRecommendations(cursor, limit, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary 장소 검색 추천을 수정한다.
+         * @param {string} id PlaceSearchRecommendation ID
+         * @param {AdminUpdatePlaceSearchRecommendationRequestDto} adminUpdatePlaceSearchRecommendationRequestDto 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updatePlaceSearchRecommendation(id: string, adminUpdatePlaceSearchRecommendationRequestDto: AdminUpdatePlaceSearchRecommendationRequestDto, options?: any): AxiosPromise<AdminPlaceSearchRecommendationDto> {
+            return localVarFp.updatePlaceSearchRecommendation(id, adminUpdatePlaceSearchRecommendationRequestDto, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * PlaceSearchRecommendationApi - object-oriented interface
+ * @export
+ * @class PlaceSearchRecommendationApi
+ * @extends {BaseAPI}
+ */
+export class PlaceSearchRecommendationApi extends BaseAPI {
+    /**
+     * 
+     * @summary 장소 검색 추천을 생성한다.
+     * @param {AdminCreatePlaceSearchRecommendationRequestDto} adminCreatePlaceSearchRecommendationRequestDto 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PlaceSearchRecommendationApi
+     */
+    public createPlaceSearchRecommendation(adminCreatePlaceSearchRecommendationRequestDto: AdminCreatePlaceSearchRecommendationRequestDto, options?: AxiosRequestConfig) {
+        return PlaceSearchRecommendationApiFp(this.configuration).createPlaceSearchRecommendation(adminCreatePlaceSearchRecommendationRequestDto, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary 장소 검색 추천을 삭제한다.
+     * @param {string} id PlaceSearchRecommendation ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PlaceSearchRecommendationApi
+     */
+    public deletePlaceSearchRecommendation(id: string, options?: AxiosRequestConfig) {
+        return PlaceSearchRecommendationApiFp(this.configuration).deletePlaceSearchRecommendation(id, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary 장소 검색 추천 목록을 조회한다.
+     * @param {string} [cursor] 페이지네이션 커서
+     * @param {number} [limit] 페이지당 항목 수 (기본값 20)
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PlaceSearchRecommendationApi
+     */
+    public listPlaceSearchRecommendations(cursor?: string, limit?: number, options?: AxiosRequestConfig) {
+        return PlaceSearchRecommendationApiFp(this.configuration).listPlaceSearchRecommendations(cursor, limit, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary 장소 검색 추천을 수정한다.
+     * @param {string} id PlaceSearchRecommendation ID
+     * @param {AdminUpdatePlaceSearchRecommendationRequestDto} adminUpdatePlaceSearchRecommendationRequestDto 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PlaceSearchRecommendationApi
+     */
+    public updatePlaceSearchRecommendation(id: string, adminUpdatePlaceSearchRecommendationRequestDto: AdminUpdatePlaceSearchRecommendationRequestDto, options?: AxiosRequestConfig) {
+        return PlaceSearchRecommendationApiFp(this.configuration).updatePlaceSearchRecommendation(id, adminUpdatePlaceSearchRecommendationRequestDto, options).then((request) => request(this.axios, this.basePath));
     }
 }
 


### PR DESCRIPTION
## 개요
검색 플로우 저장리스트 노출 기능의 scc-admin 관리 UI. 설계: `specs/saved-list-search-exposure/spec.md`.

**Depends on**: Stair-Crusher-Club/scc-server#959

## 변경
- **저장리스트 폼에 `shortName`**(maxLength 8, optional) 입력 + 목록 컬럼.
- **신규 "검색 추천 관리" 페이지**: 목록(cursor infinite), 생성(type 고정 REGION_BASED, name ≤12, placeListId 셀렉터, datetime, 장소<3개 힌트), 수정(인라인), 삭제. 사이드바 메뉴 추가. **폴리곤 필드 없음**(서버 계산).

## 검증
`pnpm typecheck` 0 errors, `pnpm lint` 신규 에러 0, self-review + adversarial review PASS.

## 머지 주의
origin/main에 toilet feature(`AdminToiletApi`)가 추가돼 있어 api.ts 충돌 해소함. scc-api#115 머지 후 submodule 포인터 rebase 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "short name" field (max 8 characters) to place lists for display purposes.
  * Introduced search recommendations management feature, including create, view, edit, delete, and list capabilities with infinite-scroll pagination.
  * Added search recommendations option to main navigation menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->