### PR TITLE
fix(quest): 네이버 지도 버튼을 새 탭으로 열기

### DIFF
--- a/app/modals/BuildingDetailSheet/PlaceCard.tsx
+++ b/app/modals/BuildingDetailSheet/PlaceCard.tsx
@@ -110,7 +110,7 @@ export default function PlaceCard({ place, questId, onUpdate, onDelete }: Props)
           <S.Button onClick={openInApp}>
             <Image src={stairCrusherIcon} alt="계단뿌셔클럽" style={{ width: 24, height: 24 }} />
           </S.Button>
-          <S.Link href={`https://map.naver.com/p/search/${place.name}`}>
+          <S.Link href={`https://map.naver.com/p/search/${place.name}`} target="_blank" rel="noopener noreferrer">
             <Image src={naverMapIcon} alt="네이버 지도" style={{ width: 24, height: 24 }} />
           </S.Link>
           {authenticated ? (


### PR DESCRIPTION
## 변경 내용

퀘스트 빌딩 상세 시트(`PlaceCard`)의 네이버 지도 링크가 `<a href>` 기본 동작으로 **현재 탭에서 redirect**되어 어드민을 이탈하던 문제 수정.

- `target="_blank" rel="noopener noreferrer"` 추가 → **새 탭**에서 열림
- 같은 레포 `buildingDeduplication`/`closedPlace` 페이지의 `window.open` 동작과 일관성 확보

## 영향 반경

- `S.Link`(네이버 지도 앵커)는 PlaceCard 1곳에서만 사용. PlaceCard는 BuildingDetailSheet mobile/desktop에서 렌더.
- URL 자체는 동일(`map.naver.com/p/search/{name}`), 탭 동작만 변경.

## 검증

- `pnpm typecheck` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Naver Maps links now open in a new tab, preventing navigation away from the current page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->