### PR TITLE
feat(closedPlace): 폐업 후보 목록에 출처/근거/신뢰도 노출

### DIFF
--- a/app/(private)/closedPlace/page.tsx
+++ b/app/(private)/closedPlace/page.tsx
@@ -4,7 +4,11 @@ import dayjs from "dayjs"
 import Image from "next/image"
 import { useState } from "react"
 
-import { AdminClosedPlaceCandidateDTO } from "@/lib/generated-sources/openapi"
+import {
+  AdminClosedPlaceCandidateDTO,
+  AdminClosureCheckSourceDTO,
+  AdminClosureReasonDTO,
+} from "@/lib/generated-sources/openapi"
 
 import { Contents } from "@/components/layout"
 
@@ -12,6 +16,23 @@ import naverMapIcon from "../../../public/naver_map.jpg"
 import { ActionsCell } from "./components/Cells"
 import * as S from "./page.style"
 import { useClosedPlaceCandidates } from "./query"
+
+const SOURCE_LABEL: Record<AdminClosureCheckSourceDTO, string> = {
+  [AdminClosureCheckSourceDTO.NaverMapsApi]: "네이버 지도 API",
+  [AdminClosureCheckSourceDTO.NaverPlaceCrawler]: "네이버 플레이스 크롤러",
+  [AdminClosureCheckSourceDTO.PublicData]: "공공데이터",
+  [AdminClosureCheckSourceDTO.Kakao]: "카카오",
+  [AdminClosureCheckSourceDTO.Google]: "구글",
+  [AdminClosureCheckSourceDTO.Tmap]: "티맵",
+  [AdminClosureCheckSourceDTO.Manual]: "수동 입력",
+}
+
+const REASON_LABEL: Record<AdminClosureReasonDTO, string> = {
+  [AdminClosureReasonDTO.ClosedByPublicData]: "공공데이터 폐업",
+  [AdminClosureReasonDTO.NotFoundOnMap]: "지도 검색결과 없음",
+  [AdminClosureReasonDTO.LowMatchConfidence]: "매칭 신뢰도 낮음",
+  [AdminClosureReasonDTO.ManualCheck]: "수동 확인",
+}
 
 export default function ClosedPlacePage() {
   const [activeTab, setActiveTab] = useState<"all" | "registered">("all")
@@ -48,8 +69,16 @@ export default function ClosedPlacePage() {
                 {closedPlaceCandidates.map((candidate) => (
                   <S.RowWrapper key={candidate.id}>
                     <S.TextContent>
-                      {candidate.name}({candidate.address}), {dayjs(candidate.closedAt?.value).format("YYYY-MM-DD")}{" "}
-                      폐업 추정
+                      {candidate.name}({candidate.address}),{" "}
+                      {candidate.closedAt?.value
+                        ? `${dayjs(candidate.closedAt.value).format("YYYY-MM-DD")} 폐업 추정`
+                        : "폐업 추정"}
+                      {" · 출처: "}
+                      {SOURCE_LABEL[candidate.checkSource] ?? candidate.checkSource}
+                      {candidate.closureReason
+                        ? ` · 근거: ${REASON_LABEL[candidate.closureReason] ?? candidate.closureReason}`
+                        : ""}
+                      {candidate.matchConfidence != null ? ` · 신뢰도: ${candidate.matchConfidence.toFixed(2)}` : ""}
                     </S.TextContent>
                     <S.ExternalMap onClick={() => openNaverMap(candidate)}>
                       <Image src={naverMapIcon} alt="네이버 지도" />

--- a/lib/generated-sources/openapi/api.ts
+++ b/lib/generated-sources/openapi/api.ts
@@ -1207,7 +1207,60 @@ export interface AdminClosedPlaceCandidateDTO {
      * @memberof AdminClosedPlaceCandidateDTO
      */
     'ignoredAt'?: EpochMillisTimestamp;
+    /**
+     * 
+     * @type {AdminClosureCheckSourceDTO}
+     * @memberof AdminClosedPlaceCandidateDTO
+     */
+    'checkSource': AdminClosureCheckSourceDTO;
+    /**
+     * 
+     * @type {AdminClosureReasonDTO}
+     * @memberof AdminClosedPlaceCandidateDTO
+     */
+    'closureReason'?: AdminClosureReasonDTO;
+    /**
+     * 매칭 신뢰도 (0.0~1.0). 낮은 신뢰도로 폐업 추정된 경우 등에 설정, 없으면 null.
+     * @type {number}
+     * @memberof AdminClosedPlaceCandidateDTO
+     */
+    'matchConfidence'?: number;
 }
+/**
+ * 폐업 추정 소스 (어떤 방식으로 확인했는지) - NAVER_MAPS_API: 네이버 지도 API 검색 - NAVER_PLACE_CRAWLER: 네이버 플레이스 크롤링 - PUBLIC_DATA: 공공데이터 폐업 정보 - KAKAO / GOOGLE / TMAP: 각 지도 서비스 - MANUAL: 관리자 수동 입력 
+ * @export
+ * @enum {string}
+ */
+
+export const AdminClosureCheckSourceDTO = {
+    NaverMapsApi: 'NAVER_MAPS_API',
+    NaverPlaceCrawler: 'NAVER_PLACE_CRAWLER',
+    PublicData: 'PUBLIC_DATA',
+    Kakao: 'KAKAO',
+    Google: 'GOOGLE',
+    Tmap: 'TMAP',
+    Manual: 'MANUAL'
+} as const;
+
+export type AdminClosureCheckSourceDTO = typeof AdminClosureCheckSourceDTO[keyof typeof AdminClosureCheckSourceDTO];
+
+
+/**
+ * 폐업 추정 근거 (왜 폐업으로 추정했는지) - CLOSED_BY_PUBLIC_DATA: 공공데이터에서 폐업 확인 - NOT_FOUND_ON_MAP: 지도에서 검색 결과 없음 - LOW_MATCH_CONFIDENCE: 검색 결과와 일치도 낮음 - MANUAL_CHECK: 관리자 수동 확인 
+ * @export
+ * @enum {string}
+ */
+
+export const AdminClosureReasonDTO = {
+    ClosedByPublicData: 'CLOSED_BY_PUBLIC_DATA',
+    NotFoundOnMap: 'NOT_FOUND_ON_MAP',
+    LowMatchConfidence: 'LOW_MATCH_CONFIDENCE',
+    ManualCheck: 'MANUAL_CHECK'
+} as const;
+
+export type AdminClosureReasonDTO = typeof AdminClosureReasonDTO[keyof typeof AdminClosureReasonDTO];
+
+
 /**
  * 
  * @export
@@ -1670,7 +1723,7 @@ export interface AdminCreatePlaceSearchRecommendationRequestDto {
      */
     'type': AdminPlaceSearchRecommendationTypeDto;
     /**
-     * 칩에 표시하는 짧은 이름 (최대 12자)
+     * 칩에 표시하는 짧은 이름 (최대 8자)
      * @type {string}
      * @memberof AdminCreatePlaceSearchRecommendationRequestDto
      */
@@ -3945,7 +3998,7 @@ export interface AdminUpdatePlaceSearchRecommendationRequestDto {
      */
     'type': AdminPlaceSearchRecommendationTypeDto;
     /**
-     * 칩에 표시하는 짧은 이름 (최대 12자)
+     * 칩에 표시하는 짧은 이름 (최대 8자)
      * @type {string}
      * @memberof AdminUpdatePlaceSearchRecommendationRequestDto
      */


### PR DESCRIPTION
폐업 추정 목록에서 어떤 소스(네이버 지도 API / 네이버 크롤러 / 공공데이터 / 카카오 등)로, 어떤 근거로 폐업 추정됐는지 + 매칭 신뢰도를 표시.

- scc-api submodule bump (800fca3) + pnpm codegen
- 지도 소스는 폐업일이 없어 "폐업 추정"만 표시 (기존 Invalid Date 렌더 수정)

Depends on:
- scc-api https://github.com/Stair-Crusher-Club/scc-api/pull/124
- scc-server https://github.com/Stair-Crusher-Club/scc-server/pull/1011

## 검증
- pnpm typecheck / lint / build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Closure information now displays readable source and reason labels.
  - Closure dates appear only when available.
  - Match confidence is shown with two-decimal precision when provided.
  - Original values remain visible when no label mapping is available.

- **Updates**
  - Place recommendation chip length guidance has been updated to a maximum of 8 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->