### PR TITLE
fix(closedPlace): 폐업 처리 확인창의 잘못된 접근성 삭제 경고 제거

### DIFF
--- a/app/(private)/closedPlace/components/Cells.tsx
+++ b/app/(private)/closedPlace/components/Cells.tsx
@@ -8,12 +8,7 @@ import * as S from "./Cells.style"
 export function ActionsCell({ closedPlaceCandidate }: { closedPlaceCandidate: AdminClosedPlaceCandidateDTO }) {
   async function handleAcceptClosedPlaceCandidate() {
     const { id, name } = closedPlaceCandidate
-    if (
-      !confirm(
-        `정말 [${name}] 장소를 폐업 처리하겠습니까?\n접근성 정보가 등록되어 있는 경우 폐업 처리와 함께 접근성 정보가 삭제됩니다.`,
-      )
-    )
-      return
+    if (!confirm(`정말 [${name}] 장소를 폐업 처리하겠습니까?\n(접근성 정보는 삭제되지 않고 보존됩니다.)`)) return
     await acceptClosedPlaceCandidate({ id })
     toast.success(`[${name}] 장소가 폐업 처리되었습니다.`)
   }


### PR DESCRIPTION
폐업 처리는 `setIsClosed(true)`만 하고 접근성 정보를 삭제하지 않음(백엔드 확인). 확인창의 삭제 경고 문구가 stale이라 제거하고 보존됨을 명시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the closure confirmation message to clarify that accessibility information is preserved when closing a location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->