### PR TITLE
feat(placeList): 짧은 이름 → 이름칩(nameChip) + 관심 테마 입력 추가

### DIFF
--- a/app/(private)/placeList/[id]/page.tsx
+++ b/app/(private)/placeList/[id]/page.tsx
@@ -5,9 +5,12 @@ import { useEffect, useState } from "react"
 import { toast } from "react-toastify"
 
 import {
+  AdminImageUploadPurposeTypeDTO,
   AdminPlaceListAccessControlDto,
+  AdminPlaceListNameChipDto,
   AdminPlaceListPlaceDto,
   AdminSearchedPlaceDto,
+  AdminUserInterestedThemeDto,
 } from "@/lib/generated-sources/openapi"
 import {
   usePlaceListDetail,
@@ -17,9 +20,12 @@ import {
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Contents } from "@/components/layout"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import ImageUploader from "@/components/ImageUploader"
 import { ACCESS_CONTROL_LABELS, ACCESS_CONTROL_OPTIONS } from "../components/accessControl"
+import { THEME_LABELS, THEME_OPTIONS } from "../components/themes"
 import { PlaceSearchPanel } from "../components/PlaceSearchPanel"
 import { SortablePlaceList } from "../components/SortablePlaceList"
 
@@ -33,7 +39,11 @@ export default function PlaceListDetailPage() {
   const { mutateAsync: deletePlaceList, isPending: isDeleting } = useDeletePlaceList()
 
   const [name, setName] = useState("")
-  const [shortName, setShortName] = useState("")
+  const [chipText, setChipText] = useState("")
+  const [chipIconUrls, setChipIconUrls] = useState<string[]>([])
+  const [chipBackgroundColor, setChipBackgroundColor] = useState("")
+  const [chipBorderColor, setChipBorderColor] = useState("")
+  const [themes, setThemes] = useState<AdminUserInterestedThemeDto[]>([])
   const [description, setDescription] = useState("")
   const [iconColor, setIconColor] = useState("#FFC01E")
   const [accessControl, setAccessControl] = useState<AdminPlaceListAccessControlDto>(
@@ -44,7 +54,11 @@ export default function PlaceListDetailPage() {
   useEffect(() => {
     if (placeList) {
       setName(placeList.name)
-      setShortName(placeList.shortName ?? "")
+      setChipText(placeList.nameChip?.text ?? "")
+      setChipIconUrls(placeList.nameChip?.iconUrl ? [placeList.nameChip.iconUrl] : [])
+      setChipBackgroundColor(placeList.nameChip?.backgroundColor ?? "")
+      setChipBorderColor(placeList.nameChip?.borderColor ?? "")
+      setThemes(placeList.themes)
       setDescription(placeList.description ?? "")
       setIconColor(placeList.iconColor ?? "#FFC01E")
       setAccessControl(placeList.accessControl)
@@ -52,13 +66,31 @@ export default function PlaceListDetailPage() {
     }
   }, [placeList])
 
+  const toggleTheme = (theme: AdminUserInterestedThemeDto) => {
+    setThemes((prev) => (prev.includes(theme) ? prev.filter((t) => t !== theme) : [...prev, theme]))
+  }
+
   const handleSave = async () => {
+    // 문구가 비면 아이콘/색 지정 여부와 무관하게 nameChip 전체를 null로 전송한다.
+    // 서버 PlaceListNameChip.text는 blank를 허용하지 않으므로(require) 문구 없이 저장할 수 없다.
+    const nameChip: AdminPlaceListNameChipDto | null = chipText.trim()
+      ? {
+          text: chipText.trim(),
+          iconUrl: chipIconUrls[0] ?? null,
+          backgroundColor: chipBackgroundColor || null,
+          borderColor: chipBorderColor || null,
+        }
+      : null
+
     try {
       await updatePlaceList({
         id: placeListId,
         data: {
           name,
-          shortName: shortName || null,
+          // ponytail: openapi generator가 $ref 옆의 `nullable: true`를 무시해 생성 타입에 `| null`이 빠졌다.
+          // 실제로는 null을 그대로 보내야 하므로(undefined면 필드 자체가 누락) 타입만 캐스팅한다.
+          nameChip: nameChip as AdminPlaceListNameChipDto | undefined,
+          themes,
           description: description || null,
           iconColor: iconColor || null,
           accessControl,
@@ -130,17 +162,92 @@ export default function PlaceListDetailPage() {
               />
             </div>
 
-            <div className="space-y-2">
-              <label className="text-sm font-medium">
-                짧은 이름 <span className="text-muted-foreground text-xs">(최대 8자, 검색 태그에 표시)</span>
-              </label>
-              <input
-                value={shortName}
-                onChange={(e) => setShortName(e.target.value)}
-                className="w-full px-3 py-2 border rounded-md"
-                placeholder="예: 홍대핫플"
-                maxLength={8}
+            <div className="space-y-3 rounded-md border p-4">
+              <div>
+                <h4 className="text-sm font-semibold">이름칩</h4>
+                <p className="text-xs text-muted-foreground">
+                  검색 카드/장소상세/리스트상세에 공통으로 노출되는 칩입니다. 미지정 시 기본 칩 디자인으로 노출됩니다.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">칩 문구</label>
+                <input
+                  value={chipText}
+                  onChange={(e) => setChipText(e.target.value)}
+                  className="w-full px-3 py-2 border rounded-md"
+                  placeholder="예: 홍대핫플"
+                />
+                <p className="text-xs text-muted-foreground">
+                  문구가 비어 있으면 이름칩 전체가 사라지며, 아래 아이콘/색상 지정도 함께 무시됩니다.
+                </p>
+              </div>
+
+              <ImageUploader
+                value={chipIconUrls}
+                onChange={setChipIconUrls}
+                purposeType={AdminImageUploadPurposeTypeDTO.Banner}
+                maxImages={1}
+                label="칩 아이콘"
               />
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">칩 배경색</label>
+                <div className="flex items-center gap-3">
+                  <input
+                    type="color"
+                    value={chipBackgroundColor || "#FFFFFF"}
+                    onChange={(e) => setChipBackgroundColor(e.target.value)}
+                    className="w-10 h-10 rounded cursor-pointer border"
+                  />
+                  <input
+                    value={chipBackgroundColor}
+                    onChange={(e) => setChipBackgroundColor(e.target.value)}
+                    className="w-32 px-3 py-2 border rounded-md font-mono text-sm"
+                    placeholder="미지정"
+                  />
+                  {chipBackgroundColor && (
+                    <Button type="button" variant="ghost" size="sm" onClick={() => setChipBackgroundColor("")}>
+                      지우기
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">칩 테두리색</label>
+                <div className="flex items-center gap-3">
+                  <input
+                    type="color"
+                    value={chipBorderColor || "#FFFFFF"}
+                    onChange={(e) => setChipBorderColor(e.target.value)}
+                    className="w-10 h-10 rounded cursor-pointer border"
+                  />
+                  <input
+                    value={chipBorderColor}
+                    onChange={(e) => setChipBorderColor(e.target.value)}
+                    className="w-32 px-3 py-2 border rounded-md font-mono text-sm"
+                    placeholder="미지정"
+                  />
+                  {chipBorderColor && (
+                    <Button type="button" variant="ghost" size="sm" onClick={() => setChipBorderColor("")}>
+                      지우기
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">관심 테마</label>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                {THEME_OPTIONS.map((theme) => (
+                  <label key={theme} className="flex items-center gap-2 text-sm">
+                    <Checkbox checked={themes.includes(theme)} onCheckedChange={() => toggleTheme(theme)} />
+                    {THEME_LABELS[theme]}
+                  </label>
+                ))}
+              </div>
             </div>
 
             <div className="space-y-2">

--- a/app/(private)/placeList/components/columns.tsx
+++ b/app/(private)/placeList/components/columns.tsx
@@ -20,12 +20,12 @@ export const getColumns = (): ColumnDef<AdminPlaceListDto>[] => [
     },
   },
   {
-    accessorKey: "shortName",
-    header: "짧은 이름",
+    accessorKey: "nameChip",
+    header: "이름칩",
     cell: ({ row }) => {
       return (
         <div className="text-sm text-muted-foreground">
-          {row.original.shortName ?? "-"}
+          {row.original.nameChip?.text ?? "-"}
         </div>
       )
     },

--- a/app/(private)/placeList/components/themes.ts
+++ b/app/(private)/placeList/components/themes.ts
@@ -1,0 +1,24 @@
+import { AdminUserInterestedThemeDto } from "@/lib/generated-sources/openapi"
+
+// 앱 InterestedRegionAndThemesFormScreen/constants.ts의 THEME_LABEL_BY_VALUE와 동일 문구
+export const THEME_LABELS: Record<AdminUserInterestedThemeDto, string> = {
+  [AdminUserInterestedThemeDto.WheelchairReview]: "🧑‍🦽 휠체어 찐방문기",
+  [AdminUserInterestedThemeDto.MediaHotspot]: "🔥 방송·SNS 핫플",
+  [AdminUserInterestedThemeDto.FoodCafeTour]: "🍕 맛집·카페 투어",
+  [AdminUserInterestedThemeDto.EmotionalView]: "📸 감성·뷰 맛집",
+  [AdminUserInterestedThemeDto.Sports]: "⚾ 야구장·스포츠",
+  [AdminUserInterestedThemeDto.Culture]: "🎭 공연·전시·영화",
+  [AdminUserInterestedThemeDto.Travel]: "✈️ 훌쩍 떠나는 여행",
+  [AdminUserInterestedThemeDto.Nature]: "🌳 자연·공원 힐링",
+}
+
+export const THEME_OPTIONS: AdminUserInterestedThemeDto[] = [
+  AdminUserInterestedThemeDto.WheelchairReview,
+  AdminUserInterestedThemeDto.MediaHotspot,
+  AdminUserInterestedThemeDto.FoodCafeTour,
+  AdminUserInterestedThemeDto.EmotionalView,
+  AdminUserInterestedThemeDto.Sports,
+  AdminUserInterestedThemeDto.Culture,
+  AdminUserInterestedThemeDto.Travel,
+  AdminUserInterestedThemeDto.Nature,
+]

--- a/app/(private)/placeList/create/page.tsx
+++ b/app/(private)/placeList/create/page.tsx
@@ -4,14 +4,23 @@ import { useRouter } from "next/navigation"
 import { useState } from "react"
 import { toast } from "react-toastify"
 
-import { AdminPlaceListAccessControlDto, AdminSearchedPlaceDto } from "@/lib/generated-sources/openapi"
+import {
+  AdminImageUploadPurposeTypeDTO,
+  AdminPlaceListAccessControlDto,
+  AdminPlaceListNameChipDto,
+  AdminUserInterestedThemeDto,
+  AdminSearchedPlaceDto,
+} from "@/lib/generated-sources/openapi"
 import { useCreatePlaceList } from "@/lib/apis/placeList"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Contents } from "@/components/layout"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import ImageUploader from "@/components/ImageUploader"
 import { ACCESS_CONTROL_LABELS, ACCESS_CONTROL_OPTIONS } from "../components/accessControl"
+import { THEME_LABELS, THEME_OPTIONS } from "../components/themes"
 import { PlaceSearchPanel } from "../components/PlaceSearchPanel"
 import { SortablePlaceList } from "../components/SortablePlaceList"
 
@@ -20,7 +29,11 @@ export default function PlaceListCreatePage() {
   const { mutateAsync: createPlaceList, isPending: isCreating } = useCreatePlaceList()
 
   const [name, setName] = useState("")
-  const [shortName, setShortName] = useState("")
+  const [chipText, setChipText] = useState("")
+  const [chipIconUrls, setChipIconUrls] = useState<string[]>([])
+  const [chipBackgroundColor, setChipBackgroundColor] = useState("")
+  const [chipBorderColor, setChipBorderColor] = useState("")
+  const [themes, setThemes] = useState<AdminUserInterestedThemeDto[]>([])
   const [description, setDescription] = useState("")
   const [iconColor, setIconColor] = useState("#FFC01E")
   const [accessControl, setAccessControl] = useState<AdminPlaceListAccessControlDto>(
@@ -28,11 +41,29 @@ export default function PlaceListCreatePage() {
   )
   const [places, setPlaces] = useState<AdminSearchedPlaceDto[]>([])
 
+  const toggleTheme = (theme: AdminUserInterestedThemeDto) => {
+    setThemes((prev) => (prev.includes(theme) ? prev.filter((t) => t !== theme) : [...prev, theme]))
+  }
+
   const handleCreate = async () => {
+    // 문구가 비면 아이콘/색 지정 여부와 무관하게 nameChip 전체를 null로 전송한다.
+    // 서버 PlaceListNameChip.text는 blank를 허용하지 않으므로(require) 문구 없이 저장할 수 없다.
+    const nameChip: AdminPlaceListNameChipDto | null = chipText.trim()
+      ? {
+          text: chipText.trim(),
+          iconUrl: chipIconUrls[0] ?? null,
+          backgroundColor: chipBackgroundColor || null,
+          borderColor: chipBorderColor || null,
+        }
+      : null
+
     try {
       await createPlaceList({
         name,
-        shortName: shortName || null,
+        // ponytail: openapi generator가 $ref 옆의 `nullable: true`를 무시해 생성 타입에 `| null`이 빠졌다.
+        // 실제로는 null을 그대로 보내야 하므로(undefined면 필드 자체가 누락) 타입만 캐스팅한다.
+        nameChip: nameChip as AdminPlaceListNameChipDto | undefined,
+        themes,
         description: description || null,
         iconColor: iconColor || null,
         accessControl,
@@ -76,17 +107,92 @@ export default function PlaceListCreatePage() {
               />
             </div>
 
-            <div className="space-y-2">
-              <label className="text-sm font-medium">
-                짧은 이름 <span className="text-muted-foreground text-xs">(최대 8자, 검색 태그에 표시)</span>
-              </label>
-              <input
-                value={shortName}
-                onChange={(e) => setShortName(e.target.value)}
-                className="w-full px-3 py-2 border rounded-md"
-                placeholder="예: 홍대핫플"
-                maxLength={8}
+            <div className="space-y-3 rounded-md border p-4">
+              <div>
+                <h4 className="text-sm font-semibold">이름칩</h4>
+                <p className="text-xs text-muted-foreground">
+                  검색 카드/장소상세/리스트상세에 공통으로 노출되는 칩입니다. 미지정 시 기본 칩 디자인으로 노출됩니다.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">칩 문구</label>
+                <input
+                  value={chipText}
+                  onChange={(e) => setChipText(e.target.value)}
+                  className="w-full px-3 py-2 border rounded-md"
+                  placeholder="예: 홍대핫플"
+                />
+                <p className="text-xs text-muted-foreground">
+                  문구가 비어 있으면 이름칩 전체가 사라지며, 아래 아이콘/색상 지정도 함께 무시됩니다.
+                </p>
+              </div>
+
+              <ImageUploader
+                value={chipIconUrls}
+                onChange={setChipIconUrls}
+                purposeType={AdminImageUploadPurposeTypeDTO.Banner}
+                maxImages={1}
+                label="칩 아이콘"
               />
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">칩 배경색</label>
+                <div className="flex items-center gap-3">
+                  <input
+                    type="color"
+                    value={chipBackgroundColor || "#FFFFFF"}
+                    onChange={(e) => setChipBackgroundColor(e.target.value)}
+                    className="w-10 h-10 rounded cursor-pointer border"
+                  />
+                  <input
+                    value={chipBackgroundColor}
+                    onChange={(e) => setChipBackgroundColor(e.target.value)}
+                    className="w-32 px-3 py-2 border rounded-md font-mono text-sm"
+                    placeholder="미지정"
+                  />
+                  {chipBackgroundColor && (
+                    <Button type="button" variant="ghost" size="sm" onClick={() => setChipBackgroundColor("")}>
+                      지우기
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium">칩 테두리색</label>
+                <div className="flex items-center gap-3">
+                  <input
+                    type="color"
+                    value={chipBorderColor || "#FFFFFF"}
+                    onChange={(e) => setChipBorderColor(e.target.value)}
+                    className="w-10 h-10 rounded cursor-pointer border"
+                  />
+                  <input
+                    value={chipBorderColor}
+                    onChange={(e) => setChipBorderColor(e.target.value)}
+                    className="w-32 px-3 py-2 border rounded-md font-mono text-sm"
+                    placeholder="미지정"
+                  />
+                  {chipBorderColor && (
+                    <Button type="button" variant="ghost" size="sm" onClick={() => setChipBorderColor("")}>
+                      지우기
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">관심 테마</label>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                {THEME_OPTIONS.map((theme) => (
+                  <label key={theme} className="flex items-center gap-2 text-sm">
+                    <Checkbox checked={themes.includes(theme)} onCheckedChange={() => toggleTheme(theme)} />
+                    {THEME_LABELS[theme]}
+                  </label>
+                ))}
+              </div>
             </div>
 
             <div className="space-y-2">

--- a/lib/generated-sources/openapi/api.ts
+++ b/lib/generated-sources/openapi/api.ts
@@ -1674,12 +1674,6 @@ export interface AdminCreatePlaceListRequestDto {
      */
     'name': string;
     /**
-     * 검색 결과 카드 등 공간이 좁은 곳에 표시하는 짧은 이름 (최대 8자).
-     * @type {string}
-     * @memberof AdminCreatePlaceListRequestDto
-     */
-    'shortName'?: string | null;
-    /**
      * 
      * @type {string}
      * @memberof AdminCreatePlaceListRequestDto
@@ -1697,6 +1691,18 @@ export interface AdminCreatePlaceListRequestDto {
      * @memberof AdminCreatePlaceListRequestDto
      */
     'iconColor'?: string | null;
+    /**
+     * 
+     * @type {AdminPlaceListNameChipDto}
+     * @memberof AdminCreatePlaceListRequestDto
+     */
+    'nameChip'?: AdminPlaceListNameChipDto;
+    /**
+     * 저장리스트에 지정할 관심 테마 목록. 지정 안 하면 빈 배열로 저장.
+     * @type {Array<AdminUserInterestedThemeDto>}
+     * @memberof AdminCreatePlaceListRequestDto
+     */
+    'themes'?: Array<AdminUserInterestedThemeDto>;
     /**
      * 
      * @type {AdminPlaceListAccessControlDto}
@@ -2676,12 +2682,6 @@ export interface AdminPlaceListDetailDto {
      */
     'name': string;
     /**
-     * 검색 결과 카드 등 공간이 좁은 곳에 표시하는 짧은 이름 (최대 8자).
-     * @type {string}
-     * @memberof AdminPlaceListDetailDto
-     */
-    'shortName'?: string | null;
-    /**
      * 
      * @type {string}
      * @memberof AdminPlaceListDetailDto
@@ -2699,6 +2699,18 @@ export interface AdminPlaceListDetailDto {
      * @memberof AdminPlaceListDetailDto
      */
     'iconColor'?: string | null;
+    /**
+     * 
+     * @type {AdminPlaceListNameChipDto}
+     * @memberof AdminPlaceListDetailDto
+     */
+    'nameChip'?: AdminPlaceListNameChipDto;
+    /**
+     * 저장리스트에 지정된 관심 테마 목록. 지정 안 하면 빈 배열.
+     * @type {Array<AdminUserInterestedThemeDto>}
+     * @memberof AdminPlaceListDetailDto
+     */
+    'themes': Array<AdminUserInterestedThemeDto>;
     /**
      * 
      * @type {AdminPlaceListAccessControlDto}
@@ -2743,12 +2755,6 @@ export interface AdminPlaceListDto {
      */
     'name': string;
     /**
-     * 검색 결과 카드 등 공간이 좁은 곳에 표시하는 짧은 이름 (최대 8자).
-     * @type {string}
-     * @memberof AdminPlaceListDto
-     */
-    'shortName'?: string | null;
-    /**
      * 
      * @type {string}
      * @memberof AdminPlaceListDto
@@ -2774,6 +2780,18 @@ export interface AdminPlaceListDto {
     'placeCount': number;
     /**
      * 
+     * @type {AdminPlaceListNameChipDto}
+     * @memberof AdminPlaceListDto
+     */
+    'nameChip'?: AdminPlaceListNameChipDto;
+    /**
+     * 저장리스트에 지정된 관심 테마 목록. 지정 안 하면 빈 배열.
+     * @type {Array<AdminUserInterestedThemeDto>}
+     * @memberof AdminPlaceListDto
+     */
+    'themes': Array<AdminUserInterestedThemeDto>;
+    /**
+     * 
      * @type {AdminPlaceListAccessControlDto}
      * @memberof AdminPlaceListDto
      */
@@ -2790,6 +2808,37 @@ export interface AdminPlaceListDto {
      * @memberof AdminPlaceListDto
      */
     'updatedAt': EpochMillisTimestamp;
+}
+/**
+ * 저장리스트 이름칩. 검색 카드/PDP/상세화면에 공통으로 쓰이는 칩 하나의 표현.
+ * @export
+ * @interface AdminPlaceListNameChipDto
+ */
+export interface AdminPlaceListNameChipDto {
+    /**
+     * 칩 표시 문구
+     * @type {string}
+     * @memberof AdminPlaceListNameChipDto
+     */
+    'text': string;
+    /**
+     * 칩 좌측 아이콘 이미지 URL. null이면 기본 저장리스트 배지 아이콘 사용.
+     * @type {string}
+     * @memberof AdminPlaceListNameChipDto
+     */
+    'iconUrl'?: string | null;
+    /**
+     * 칩 배경색 hex (예 \"#FFFFFF\"). null이면 기본 스타일.
+     * @type {string}
+     * @memberof AdminPlaceListNameChipDto
+     */
+    'backgroundColor'?: string | null;
+    /**
+     * 칩 테두리색 hex (예 \"#C4132F\"). null이면 기본 스타일.
+     * @type {string}
+     * @memberof AdminPlaceListNameChipDto
+     */
+    'borderColor'?: string | null;
 }
 /**
  * 저장 리스트에 포함된 장소 정보
@@ -3949,12 +3998,6 @@ export interface AdminUpdatePlaceListRequestDto {
      */
     'name': string;
     /**
-     * 검색 결과 카드 등 공간이 좁은 곳에 표시하는 짧은 이름 (최대 8자).
-     * @type {string}
-     * @memberof AdminUpdatePlaceListRequestDto
-     */
-    'shortName'?: string | null;
-    /**
      * 
      * @type {string}
      * @memberof AdminUpdatePlaceListRequestDto
@@ -3972,6 +4015,18 @@ export interface AdminUpdatePlaceListRequestDto {
      * @memberof AdminUpdatePlaceListRequestDto
      */
     'iconColor'?: string | null;
+    /**
+     * 
+     * @type {AdminPlaceListNameChipDto}
+     * @memberof AdminUpdatePlaceListRequestDto
+     */
+    'nameChip'?: AdminPlaceListNameChipDto;
+    /**
+     * 저장리스트에 지정할 관심 테마 목록. 지정 안 하면 빈 배열로 저장.
+     * @type {Array<AdminUserInterestedThemeDto>}
+     * @memberof AdminUpdatePlaceListRequestDto
+     */
+    'themes'?: Array<AdminUserInterestedThemeDto>;
     /**
      * 
      * @type {AdminPlaceListAccessControlDto}
@@ -4090,6 +4145,26 @@ export interface AdminUpdateSubBuildingRequestDTO {
      */
     'notes'?: string;
 }
+/**
+ * 사용자의 관심 테마. 윌리의 외출 NUX 튜토리얼 첫 번째 메인 미션에서 선택한다. Figma 1427-8980 화면 기준 8개 항목. - WHEELCHAIR_REVIEW: 휠체어 찐방문기 - MEDIA_HOTSPOT: 방송·SNS 핫플 - FOOD_CAFE_TOUR: 맛집·카페 투어 - EMOTIONAL_VIEW: 감성·뷰 맛집 - SPORTS: 야구장·스포츠 - CULTURE: 공연·전시·영화 - TRAVEL: 훌쩍 떠나는 여행 - NATURE: 자연·공원 힐링 
+ * @export
+ * @enum {string}
+ */
+
+export const AdminUserInterestedThemeDto = {
+    WheelchairReview: 'WHEELCHAIR_REVIEW',
+    MediaHotspot: 'MEDIA_HOTSPOT',
+    FoodCafeTour: 'FOOD_CAFE_TOUR',
+    EmotionalView: 'EMOTIONAL_VIEW',
+    Sports: 'SPORTS',
+    Culture: 'CULTURE',
+    Travel: 'TRAVEL',
+    Nature: 'NATURE'
+} as const;
+
+export type AdminUserInterestedThemeDto = typeof AdminUserInterestedThemeDto[keyof typeof AdminUserInterestedThemeDto];
+
+
 /**
  * 검수 결과 반영 시 수행된 작업
  * @export


### PR DESCRIPTION
서버 PR: https://github.com/Stair-Crusher-Club/scc-server/pull/1017
API 스펙 PR: https://github.com/Stair-Crusher-Club/scc-api/pull/125
Spec: `scc-workspace/specs/place-list-chips/spec.md`

## 배경

저장리스트 칩에 아이콘/배경색/테두리색을 지정할 수 있게 되면서, 기존 `shortName`(텍스트 8자)이 `nameChip` VO로 확장됐다. 어드민에서 그 4개 필드와 관심 테마를 입력할 수 있게 한다.

## 변경

| 파일 | 내용 |
|---|---|
| `placeList/create/page.tsx`, `placeList/[id]/page.tsx` | 「짧은 이름」 `<input maxLength={8}>` 삭제 → **이름칩 fieldset**(칩 문구 / 아이콘 / 배경색 / 테두리색) + **관심 테마 8종 체크박스** |
| `placeList/components/themes.ts` | **신규** — 테마 라벨·옵션 단일 소스 |
| `placeList/components/columns.tsx` | 「짧은 이름」 컬럼 → 「이름칩」(`nameChip?.text ?? "-"`) |

- 아이콘 업로드는 기존 `app/components/ImageUploader.tsx`를 `maxImages={1}` `purposeType="BANNER"`로 **재사용**했다. 새 업로더를 만들지 않았고, `PLACE_LIST` purpose enum도 신설하지 않았다 — `purposeType`은 버킷 선택에만 쓰이고 object key는 purpose와 무관해서 기능 차이가 0이다.
- 배경색/테두리색은 같은 페이지의 `iconColor`가 쓰던 `<input type="color">` + hex input 쌍 패턴을 그대로 따르고, "지우기" 버튼으로 미지정(null)을 만들 수 있다.
- 테마 라벨은 앱(`InterestedRegionAndThemesFormScreen/constants.ts`)과 **동일 문구**를 쓴다.

## 전송 규칙 (서버 500 방지)

칩 문구가 비면 아이콘/색 지정 여부와 무관하게 `nameChip` 전체를 `null`로 보낸다. 서버 `PlaceListNameChip`이 `require(text.isNotBlank())`라 문구 없이는 저장할 수 없다.

## 알려진 codegen 제약

openapi-generator가 `$ref` 옆의 `nullable: true`를 무시해 생성 타입에 `| null`이 빠진다. 읽기 경로는 optional(`?`)로 나와 무해하지만, **쓰기 경로는 명시적 `null`을 보내야 칩이 지워지므로** 타입 캐스팅으로 처리했다(`ponytail:` 주석으로 이유를 남겨둠). 스펙 변경 사항은 아니다.

## 검증

`pnpm panda && pnpm codegen && pnpm typecheck` 0 error, `pnpm lint` 0 error, `pnpm build` 성공. `shortName` 잔존 참조 0건(생성 코드 제외).

## Out of Scope

`create`/`[id]` 두 페이지의 ~95% 중복 제거 리팩터링(기존부터 있던 문제라 이번 diff에서 분리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable name chips for place lists, including text, icon, background color, and border color.
  * Added interest theme selection when creating or editing place lists.
  * Updated place list displays to show name chip text.
  * Added support for managing name chip and theme settings when saving place lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->