### PR TITLE
feat(closedPlace): 폐업 추정 근거가 된 원본 레코드 노출

### DIFF
--- a/app/(private)/closedPlace/page.style.ts
+++ b/app/(private)/closedPlace/page.style.ts
@@ -30,6 +30,15 @@ export const TextContent = styled("p", {
   },
 })
 
+export const OriginalRecord = styled("span", {
+  base: {
+    display: "block",
+    marginTop: "4px",
+    fontSize: "13px",
+    color: "#888",
+  },
+})
+
 export const ExternalMap = styled("div", {
   base: {
     cursor: "pointer",

--- a/app/(private)/closedPlace/page.tsx
+++ b/app/(private)/closedPlace/page.tsx
@@ -79,6 +79,14 @@ export default function ClosedPlacePage() {
                         ? ` · 근거: ${REASON_LABEL[candidate.closureReason] ?? candidate.closureReason}`
                         : ""}
                       {candidate.matchConfidence != null ? ` · 신뢰도: ${candidate.matchConfidence.toFixed(2)}` : ""}
+                      {/* 근거가 된 원본 레코드(공공데이터 인허가 등)의 상호명이 우리 place 이름과 다르면
+                          왜 이 장소가 폐업 추정됐는지 화면에서 알 수 없으므로 함께 보여준다. */}
+                      {candidate.originalName && candidate.originalName !== candidate.name && (
+                        <S.OriginalRecord>
+                          원본: {candidate.originalName}
+                          {candidate.originalAddress ? ` (${candidate.originalAddress})` : ""}
+                        </S.OriginalRecord>
+                      )}
                     </S.TextContent>
                     <S.ExternalMap onClick={() => openNaverMap(candidate)}>
                       <Image src={naverMapIcon} alt="네이버 지도" />

--- a/lib/generated-sources/openapi/api.ts
+++ b/lib/generated-sources/openapi/api.ts
@@ -1225,6 +1225,18 @@ export interface AdminClosedPlaceCandidateDTO {
      * @memberof AdminClosedPlaceCandidateDTO
      */
     'matchConfidence'?: number;
+    /**
+     * 폐업 추정의 근거가 된 원본 레코드의 상호명. PUBLIC_DATA면 공공데이터(행안부 인허가) 상호명이라 우리 place 이름과 다를 수 있다.
+     * @type {string}
+     * @memberof AdminClosedPlaceCandidateDTO
+     */
+    'originalName'?: string;
+    /**
+     * 폐업 추정의 근거가 된 원본 레코드의 주소.
+     * @type {string}
+     * @memberof AdminClosedPlaceCandidateDTO
+     */
+    'originalAddress'?: string;
 }
 /**
  * 폐업 추정 소스 (어떤 방식으로 확인했는지) - NAVER_MAPS_API: 네이버 지도 API 검색 - NAVER_PLACE_CRAWLER: 네이버 플레이스 크롤링 - PUBLIC_DATA: 공공데이터 폐업 정보 - KAKAO / GOOGLE / TMAP: 각 지도 서비스 - MANUAL: 관리자 수동 입력 


### PR DESCRIPTION
## 배경

폐업 추정 장소 관리 목록은 매칭된 **우리 place**의 이름/주소만 렌더한다. 그래서 어떤 원본 레코드가 그 후보를 만들었는지 화면에서 알 수 없다.

실제 사례:
- 화면: `플러스카페 1호점(서울 종로구 종로1길 36), 2026-07-01 폐업 추정 · 출처: 공공데이터 · 신뢰도: 0.80`
- 실제 근거: 공공데이터 레코드 **`플러스까페 종로구청점`** (종로1길 36, 대림빌딩 지하1층)

이름이 달라서 "우리 DB에 없는 장소 아닌가?"라는 혼란이 발생했다.

## 변경

`originalName`이 place 이름과 다를 때만 회색 작은 글씨로 한 줄 추가:

```
플러스카페 1호점(서울 종로구 종로1길 36), 2026-07-01 폐업 추정 · 출처: 공공데이터 · 신뢰도: 0.80
  원본: 플러스까페 종로구청점 (서울특별시 종로구 종로1길 36, 대림빌딩 지하1층 (수송동))
```

- scc-api: Stair-Crusher-Club/scc-api#128
- scc-server: Stair-Crusher-Club/scc-server#1023

`pnpm codegen` / `pnpm typecheck` / `pnpm lint` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Closed-place records now show the original business name and address when they differ from the candidate place details.
  * Original record information is clearly styled for easy comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->