### PR TITLE
fix(closedPlace): 검수 필요 탭을 기본으로 + 페이지 크기 50

### DIFF
--- a/app/(private)/closedPlace/page.tsx
+++ b/app/(private)/closedPlace/page.tsx
@@ -6,6 +6,7 @@ import { useState } from "react"
 
 import {
   AdminClosedPlaceCandidateDTO,
+  AdminClosedPlaceCandidateFilterDTO,
   AdminClosureCheckSourceDTO,
   AdminClosureReasonDTO,
 } from "@/lib/generated-sources/openapi"
@@ -34,9 +35,19 @@ const REASON_LABEL: Record<AdminClosureReasonDTO, string> = {
   [AdminClosureReasonDTO.ManualCheck]: "수동 확인",
 }
 
+// 검수 큐를 기본 탭으로 둔다. 슬랙 다이제스트가 "검수 필요"라고 알린 장소가
+// 목록 정렬(후보 생성 시각) 때문에 수천 번째에 묻혀 사실상 접근 불가였다.
+const TABS = [
+  { filter: AdminClosedPlaceCandidateFilterDTO.NeedsReview, label: "검수 필요" },
+  { filter: AdminClosedPlaceCandidateFilterDTO.NeedsAction, label: "전체 미처리" },
+  { filter: AdminClosedPlaceCandidateFilterDTO.AccessibilityRegistered, label: "접근성 정보가 등록된 장소" },
+] as const
+
 export default function ClosedPlacePage() {
-  const [activeTab, setActiveTab] = useState<"all" | "registered">("all")
-  const { data, fetchNextPage, hasNextPage, refetch } = useClosedPlaceCandidates(activeTab === "registered")
+  const [activeTab, setActiveTab] = useState<AdminClosedPlaceCandidateFilterDTO>(
+    AdminClosedPlaceCandidateFilterDTO.NeedsReview,
+  )
+  const { data, fetchNextPage, hasNextPage, refetch } = useClosedPlaceCandidates(activeTab)
   const closedPlaceCandidates: AdminClosedPlaceCandidateDTO[] =
     data?.pages.flatMap((p) => p.items)?.filter((it) => it !== undefined) ?? []
 
@@ -53,12 +64,11 @@ export default function ClosedPlacePage() {
     <>
       <Contents.Normal>
         <S.TabContainer>
-          <S.Tab active={activeTab === "all"} onClick={() => setActiveTab("all")}>
-            전체
-          </S.Tab>
-          <S.Tab active={activeTab === "registered"} onClick={() => setActiveTab("registered")}>
-            접근성 정보가 등록된 장소
-          </S.Tab>
+          {TABS.map(({ filter, label }) => (
+            <S.Tab key={filter} active={activeTab === filter} onClick={() => setActiveTab(filter)}>
+              {label}
+            </S.Tab>
+          ))}
         </S.TabContainer>
         <S.TableWrapper>
           <div>

--- a/app/(private)/closedPlace/query.ts
+++ b/app/(private)/closedPlace/query.ts
@@ -1,18 +1,21 @@
 import { useInfiniteQuery } from "@tanstack/react-query"
 
 import { api } from "@/lib/apis/api"
-import { AdminClosedPlaceCandidateDTO } from "@/lib/generated-sources/openapi"
+import { AdminClosedPlaceCandidateDTO, AdminClosedPlaceCandidateFilterDTO } from "@/lib/generated-sources/openapi"
 
 export interface ListClosedPlaceCandidatesResult {
   items: AdminClosedPlaceCandidateDTO[]
   cursor: string | null
 }
 
-export function useClosedPlaceCandidates(isAccessibilityRegistered: boolean) {
+export function useClosedPlaceCandidates(filter: AdminClosedPlaceCandidateFilterDTO) {
   return useInfiniteQuery({
-    queryKey: ["@closedPlaceCandidates", isAccessibilityRegistered],
+    queryKey: ["@closedPlaceCandidates", filter],
     queryFn: ({ pageParam }) =>
-      api.default.listClosedPlaceCandidates(isAccessibilityRegistered, pageParam ?? undefined, "10").then((res) => res.data),
+      // 페이지 크기 10은 검수자가 목록을 훑기에 너무 작다 — 서버 기본값과 같은 50으로.
+      api.default
+        .listClosedPlaceCandidates(filter, undefined, pageParam ?? undefined, "50")
+        .then((res) => res.data),
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) => lastPage.cursor,
   })

--- a/lib/generated-sources/openapi/api.ts
+++ b/lib/generated-sources/openapi/api.ts
@@ -1239,6 +1239,21 @@ export interface AdminClosedPlaceCandidateDTO {
     'originalAddress'?: string;
 }
 /**
+ * 폐업 추정 후보 목록 필터 - NEEDS_REVIEW: 교차검증에서 자동 판정이 안 돼 사람 판단이 필요한 것만 (검수 큐). 검수 판정 시각 최신순. - NEEDS_ACTION: 아직 폐업 확정/무시 처리되지 않은 전체 후보 - ACCESSIBILITY_REGISTERED: NEEDS_ACTION 중 접근성 정보가 등록된 장소 
+ * @export
+ * @enum {string}
+ */
+
+export const AdminClosedPlaceCandidateFilterDTO = {
+    NeedsReview: 'NEEDS_REVIEW',
+    NeedsAction: 'NEEDS_ACTION',
+    AccessibilityRegistered: 'ACCESSIBILITY_REGISTERED'
+} as const;
+
+export type AdminClosedPlaceCandidateFilterDTO = typeof AdminClosedPlaceCandidateFilterDTO[keyof typeof AdminClosedPlaceCandidateFilterDTO];
+
+
+/**
  * 폐업 추정 소스 (어떤 방식으로 확인했는지) - NAVER_MAPS_API: 네이버 지도 API 검색 - NAVER_PLACE_CRAWLER: 네이버 플레이스 크롤링 - PUBLIC_DATA: 공공데이터 폐업 정보 - KAKAO / GOOGLE / TMAP: 각 지도 서비스 - MANUAL: 관리자 수동 입력 
  * @export
  * @enum {string}
@@ -9985,13 +10000,14 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         /**
          * 
          * @summary 폐업이 추정되는 장소의 리스트를 조회한다.
-         * @param {boolean} [isAccessibilityRegistered] 
+         * @param {AdminClosedPlaceCandidateFilterDTO} [filter] 조회 대상 필터. 생략하면 NEEDS_ACTION. 하위 호환을 위해 isAccessibilityRegistered도 계속 지원하지만, 신규 클라이언트는 이 파라미터를 쓴다.
+         * @param {boolean} [isAccessibilityRegistered] deprecated. filter&#x3D;ACCESSIBILITY_REGISTERED와 동일. filter가 있으면 무시된다.
          * @param {string} [cursor] 
          * @param {string} [limit] default 값은 50으로 설정된다.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listClosedPlaceCandidates: async (isAccessibilityRegistered?: boolean, cursor?: string, limit?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        listClosedPlaceCandidates: async (filter?: AdminClosedPlaceCandidateFilterDTO, isAccessibilityRegistered?: boolean, cursor?: string, limit?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/closed-place-candidates`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -10007,6 +10023,10 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             // authentication Admin required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (filter !== undefined) {
+                localVarQueryParameter['filter'] = filter;
+            }
 
             if (isAccessibilityRegistered !== undefined) {
                 localVarQueryParameter['isAccessibilityRegistered'] = isAccessibilityRegistered;
@@ -10596,14 +10616,15 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary 폐업이 추정되는 장소의 리스트를 조회한다.
-         * @param {boolean} [isAccessibilityRegistered] 
+         * @param {AdminClosedPlaceCandidateFilterDTO} [filter] 조회 대상 필터. 생략하면 NEEDS_ACTION. 하위 호환을 위해 isAccessibilityRegistered도 계속 지원하지만, 신규 클라이언트는 이 파라미터를 쓴다.
+         * @param {boolean} [isAccessibilityRegistered] deprecated. filter&#x3D;ACCESSIBILITY_REGISTERED와 동일. filter가 있으면 무시된다.
          * @param {string} [cursor] 
          * @param {string} [limit] default 값은 50으로 설정된다.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async listClosedPlaceCandidates(isAccessibilityRegistered?: boolean, cursor?: string, limit?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AdminListClosedPlaceCandidatesResponseDTO>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listClosedPlaceCandidates(isAccessibilityRegistered, cursor, limit, options);
+        async listClosedPlaceCandidates(filter?: AdminClosedPlaceCandidateFilterDTO, isAccessibilityRegistered?: boolean, cursor?: string, limit?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<AdminListClosedPlaceCandidatesResponseDTO>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listClosedPlaceCandidates(filter, isAccessibilityRegistered, cursor, limit, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -10943,14 +10964,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         /**
          * 
          * @summary 폐업이 추정되는 장소의 리스트를 조회한다.
-         * @param {boolean} [isAccessibilityRegistered] 
+         * @param {AdminClosedPlaceCandidateFilterDTO} [filter] 조회 대상 필터. 생략하면 NEEDS_ACTION. 하위 호환을 위해 isAccessibilityRegistered도 계속 지원하지만, 신규 클라이언트는 이 파라미터를 쓴다.
+         * @param {boolean} [isAccessibilityRegistered] deprecated. filter&#x3D;ACCESSIBILITY_REGISTERED와 동일. filter가 있으면 무시된다.
          * @param {string} [cursor] 
          * @param {string} [limit] default 값은 50으로 설정된다.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listClosedPlaceCandidates(isAccessibilityRegistered?: boolean, cursor?: string, limit?: string, options?: any): AxiosPromise<AdminListClosedPlaceCandidatesResponseDTO> {
-            return localVarFp.listClosedPlaceCandidates(isAccessibilityRegistered, cursor, limit, options).then((request) => request(axios, basePath));
+        listClosedPlaceCandidates(filter?: AdminClosedPlaceCandidateFilterDTO, isAccessibilityRegistered?: boolean, cursor?: string, limit?: string, options?: any): AxiosPromise<AdminListClosedPlaceCandidatesResponseDTO> {
+            return localVarFp.listClosedPlaceCandidates(filter, isAccessibilityRegistered, cursor, limit, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -11330,15 +11352,16 @@ export class DefaultApi extends BaseAPI {
     /**
      * 
      * @summary 폐업이 추정되는 장소의 리스트를 조회한다.
-     * @param {boolean} [isAccessibilityRegistered] 
+     * @param {AdminClosedPlaceCandidateFilterDTO} [filter] 조회 대상 필터. 생략하면 NEEDS_ACTION. 하위 호환을 위해 isAccessibilityRegistered도 계속 지원하지만, 신규 클라이언트는 이 파라미터를 쓴다.
+     * @param {boolean} [isAccessibilityRegistered] deprecated. filter&#x3D;ACCESSIBILITY_REGISTERED와 동일. filter가 있으면 무시된다.
      * @param {string} [cursor] 
      * @param {string} [limit] default 값은 50으로 설정된다.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public listClosedPlaceCandidates(isAccessibilityRegistered?: boolean, cursor?: string, limit?: string, options?: AxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).listClosedPlaceCandidates(isAccessibilityRegistered, cursor, limit, options).then((request) => request(this.axios, this.basePath));
+    public listClosedPlaceCandidates(filter?: AdminClosedPlaceCandidateFilterDTO, isAccessibilityRegistered?: boolean, cursor?: string, limit?: string, options?: AxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).listClosedPlaceCandidates(filter, isAccessibilityRegistered, cursor, limit, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**


### PR DESCRIPTION
## 문제

슬랙 다이제스트가 "⚠️ 검수 필요"라고 알린 장소를 이 화면에서 찾을 수 없었다. 목록이 후보 생성 시각순이라 검수 대상 65건이 **2,189~18,160위**(중앙값 13,336)에 묻혀 있고, 페이지 크기가 10이라 "더 불러오기"를 **약 1,334번** 눌러야 한다.

## 변경

탭 3개로 정리하고 **검수 필요를 기본 탭**으로:

| 탭 | 내용 |
|---|---|
| **검수 필요** (기본) | 교차검증에서 자동 판정이 안 된 것. 검수 판정 시각 최신순 |
| 전체 미처리 | 아직 폐업 확정/무시되지 않은 전체 후보 |
| 접근성 정보가 등록된 장소 | 위 중 접근성 정보 있는 것 |

페이지 크기 10 → 50 (서버 기본값과 동일).

- scc-api: Stair-Crusher-Club/scc-api#129
- scc-server: Stair-Crusher-Club/scc-server#1024 (**먼저 배포 필요**)

`pnpm codegen` / `typecheck` / `lint` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added closed-place candidate filters for review-needed, all unprocessed, and accessibility-registered places.
  * The closed-place page now defaults to the “검수 필요” queue.
  * Increased the number of candidates loaded per page from 10 to 50.
* **Bug Fixes**
  * Candidate results now refresh correctly when the selected filter changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->